### PR TITLE
Simplify tesseract_api using the JAX recipe; take physical inputs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ boto3
 mlflow
 numpy
 plotly
+requests
 tesseract-core

--- a/tesseract/tesseract_api.py
+++ b/tesseract/tesseract_api.py
@@ -84,18 +84,20 @@ def _exact_inverse(act_fun):
 
 
 _norm = {}
+_activated = {}
 for _name, _submodule in PARAMS.items():
     _cfg = config["parameters"][_submodule][_name]
     _act_fun, _ = get_act_and_inv_act(_cfg, activate=True)
     _norm[_name] = (_cfg["lb"], _cfg["ub"] - _cfg["lb"], _exact_inverse(_act_fun))
+    _activated[_name] = _act_fun(0.0) != 0.0
 
 
 def to_normed(name: str, physical) -> jnp.ndarray:
     """Map a physical parameter value into the normalized space tsadar expects.
 
     The logit diverges at the bounds and is nan outside them, so a value at or beyond
-    lb/ub yields a non-finite spectrum rather than an error. `check_bounds` guards the
-    apply endpoint against that.
+    lb/ub would yield a non-finite spectrum rather than an error. The bounds declared on
+    `InputSchema` guard every endpoint against that.
     """
     shift, scale, inv_act = _norm[name]
     normed = inv_act((jnp.asarray(physical, dtype=jnp.float64) - shift) / scale)
@@ -104,34 +106,35 @@ def to_normed(name: str, physical) -> jnp.ndarray:
     return normed.reshape(-1, 1)
 
 
-def check_bounds(inputs: "InputSchema") -> None:
-    """Raise if any input maps to a non-finite normalized value.
+def _bounded(name: str, what: str) -> Any:
+    """Declare a parameter's deck bounds on the schema, so they reach clients.
 
-    Tested via `to_normed` itself rather than by comparing against lb/ub, so the guard
-    cannot drift from the transform. Note the bounds are exclusive for an activated
-    parameter -- the logit is +-inf exactly at lb/ub -- but inclusive for one that is
-    not activated, where the transform is the identity.
+    The deck's lb/ub are the single source of truth: they are read out of `_norm`, which
+    is built from the same config entries `to_normed` uses, so the declared bounds cannot
+    drift from the transform. Declaring them here rather than checking them in `apply`
+    also guards the gradient endpoints, which take the same `InputSchema` and would
+    otherwise return nan outside the bounds.
+
+    Bounds are exclusive for an activated parameter -- the logit is +-inf exactly at
+    lb/ub -- and inclusive for one that is not, where the transform is the identity.
+
+    The bounds are repeated in the description because they are emitted as `gt`/`lt`
+    rather than JSON Schema's `exclusiveMinimum`/`exclusiveMaximum` (see
+    `EncodedArrayModel` in tesseract_core.runtime.array_encoding), so schema-driven
+    tooling does not generally pick them up.
     """
-    for name, (lb, span, _) in _norm.items():
-        value = float(np.asarray(getattr(inputs, name)))
-        if not np.all(np.isfinite(np.asarray(to_normed(name, value)))):
-            raise ValueError(
-                f"{name}={value} does not map to a finite normalized value; it must lie "
-                f"within the deck bounds ({lb}, {lb + span})"
-            )
-
-
-def _describe(name: str, what: str) -> str:
     lb, span, _ = _norm[name]
-    return f"{what} (physical units; deck bounds [{lb}, {lb + span}])"
+    ub = lb + span
+    limits = {"gt": lb, "lt": ub} if _activated[name] else {"ge": lb, "le": ub}
+    return Field(description=f"{what} (physical units; deck bounds [{lb}, {ub}])", **limits)
 
 
 class InputSchema(BaseModel):
-    ne: Differentiable[Float64] = Field(description=_describe("ne", "electron density"))
-    Te: Differentiable[Float64] = Field(description=_describe("Te", "electron temperature"))
-    amp1: Differentiable[Float64] = Field(description=_describe("amp1", "amplitude 1"))
-    amp2: Differentiable[Float64] = Field(description=_describe("amp2", "amplitude 2"))
-    lam: Differentiable[Float64] = Field(description=_describe("lam", "central wavelength"))
+    ne: Differentiable[Float64] = _bounded("ne", "electron density")
+    Te: Differentiable[Float64] = _bounded("Te", "electron temperature")
+    amp1: Differentiable[Float64] = _bounded("amp1", "amplitude 1")
+    amp2: Differentiable[Float64] = _bounded("amp2", "amplitude 2")
+    lam: Differentiable[Float64] = _bounded("lam", "central wavelength")
 
 
 class OutputSchema(BaseModel):
@@ -160,7 +163,6 @@ def apply_jit(inputs: dict) -> dict:
 
 
 def apply(inputs: InputSchema) -> OutputSchema:
-    check_bounds(inputs)
     return OutputSchema(**jax_apply(apply_jit, inputs))
 
 

--- a/tesseract/tesseract_api.py
+++ b/tesseract/tesseract_api.py
@@ -2,16 +2,25 @@ from jax import config as jax_config
 
 jax_config.update("jax_enable_x64", True)
 
+from typing import Any
+
 import equinox as eqx
 import numpy as np
 import yaml
 from flatten_dict import flatten, unflatten
-from jax import jacrev, jit, numpy as jnp
+from jax import numpy as jnp
 from pydantic import BaseModel, Field
 from tsadar import ThomsonParams, ThomsonScatteringDiagnostic, get_scattering_angles
-from tsadar.core.modules.ts_params import get_filter_spec
+from tsadar.core.modules.ts_params import get_act_and_inv_act
 
-from tesseract_core.runtime import Array, Differentiable, Float64, ShapeDType
+from tesseract_core.runtime import Array, Differentiable, Float64
+from tesseract_core.runtime.jax_recipes import (
+    jax_abstract_eval,
+    jax_apply,
+    jax_jacobian,
+    jax_jvp,
+    jax_vjp,
+)
 
 with open("1d-defaults.yaml") as fi:
     defaults = yaml.safe_load(fi)
@@ -23,7 +32,11 @@ defaults = flatten(defaults)
 defaults.update(flatten(inputs))
 config = unflatten(defaults)
 
-# get scattering angles and weights
+# TODO: this block is duplicated at ~16 sites in tsadar (forward/calc_series.py, the
+# forward/inverse test suites, bench_*.py). It belongs upstream as
+# tsadar.forward.prepare_forward_config(config) -> (config, sas).
+# Note lamrangE/lamrangI have a different source in inverse mode, where
+# utils/process/prepare.py takes them from the calibrated data axis instead.
 config["other"]["lamrangE"] = [
     config["data"]["fit_rng"]["forward_epw_start"],
     config["data"]["fit_rng"]["forward_epw_end"],
@@ -33,7 +46,12 @@ config["other"]["lamrangI"] = [
     config["data"]["fit_rng"]["forward_iaw_end"],
 ]
 config["other"]["npts"] = int(config["other"]["CCDsize"][1] * config["other"]["points_per_pixel"])
+
 sas = get_scattering_angles(config)
+ts_params = ThomsonParams(config["parameters"], num_params=1, batch=True, activate=True)
+ts_diag = ThomsonScatteringDiagnostic(config, sas)
+
+# The forward model is evaluated without data, so the batch only has to carry shapes.
 dummy_batch = {
     "i_data": np.array([1]),
     "e_data": np.array([1]),
@@ -42,88 +60,131 @@ dummy_batch = {
     "e_amps": np.array([1]),
     "i_amps": np.array([1]),
 }
-ts_params = ThomsonParams(config["parameters"], num_params=1, batch=True, activate=True)
-ts_diag = ThomsonScatteringDiagnostic(config, sas)
 
-# filter all static parameters from the python object required to rebuild the model
-base_diff_params, static_params = eqx.partition(
-    ts_params,
-    filter_spec=get_filter_spec(cfg_params=config["parameters"], ts_params=ts_params),
-)
+# Which ThomsonParams submodule owns each parameter we expose.
+PARAMS = {"ne": "electron", "Te": "electron", "amp1": "general", "amp2": "general", "lam": "general"}
 
-
-def to_arr(x):
-    """Convert a float to a numpy array."""
-    return jnp.array(np.array(x, dtype=np.float64)).reshape(-1, 1)
-
-
-def initialize_thomson_params(inputs):
-    diff_params_REST = inputs.model_dump()
-    _diff_params = eqx.tree_at(lambda x: x.electron.normed_ne, base_diff_params, to_arr(diff_params_REST["ne"]))
-    _diff_params = eqx.tree_at(lambda x: x.electron.normed_Te, _diff_params, to_arr(diff_params_REST["Te"]))
-    _diff_params = eqx.tree_at(lambda x: x.general.normed_amp1, _diff_params, to_arr(diff_params_REST["amp1"]))
-    _diff_params = eqx.tree_at(lambda x: x.general.normed_amp2, _diff_params, to_arr(diff_params_REST["amp2"]))
-    _diff_params = eqx.tree_at(lambda x: x.general.normed_lam, _diff_params, to_arr(diff_params_REST["lam"]))
-
-    return _diff_params
+# tsadar stores parameters in a rescaled, optionally logit-transformed space and undoes
+# that as `act_fun(normed) * scale + shift` (ts_params.ElectronParams.get_unnormed_params).
+# Writing to `normed_*` directly would make this Tesseract's inputs depend on the deck's
+# lb/ub *and* on its `active` flags, which decide whether act_fun is a sigmoid or the
+# identity. So we invert the transform here and take physical units on the wire instead.
+#
+# We deliberately do NOT reuse tsadar's `inv_act_fun`. Its stabilized form,
+# log(1e-2 + x / (1 - x + 1e-2)), is not the exact inverse of `sigmoid`: round-tripping
+# the midpoint gives 0.49759 rather than 0.5, an error of ~0.24% of the parameter's
+# span. (tsadar carries that error itself -- the physical value it uses is not quite the
+# deck's `val` -- but a Tesseract whose inputs are declared physical should honour them
+# exactly, so we use the true inverse instead.)
+def _exact_inverse(act_fun):
+    """Exact inverse of the activation `get_act_and_inv_act` paired with this config."""
+    if act_fun(0.0) == 0.0:  # identity: parameter is not activated
+        return lambda x: x
+    return lambda x: jnp.log(x) - jnp.log1p(-x)  # logit, the true inverse of sigmoid
 
 
-def _ts_diag_wrapper(_diff_params):
-    # combine the differentiable parameters with the static parameters
-    _all_params = eqx.combine(_diff_params, static_params)
-    e_spec, _, _, _ = ts_diag(_all_params, dummy_batch)
-    return e_spec
+_norm = {}
+for _name, _submodule in PARAMS.items():
+    _cfg = config["parameters"][_submodule][_name]
+    _act_fun, _ = get_act_and_inv_act(_cfg, activate=True)
+    _norm[_name] = (_cfg["lb"], _cfg["ub"] - _cfg["lb"], _exact_inverse(_act_fun))
 
 
-# precompile the jacobian function to speed up the computation
-jac_fn = jit(jacrev(_ts_diag_wrapper))
-ts_diag_wrapper = jit(_ts_diag_wrapper)
+def to_normed(name: str, physical) -> jnp.ndarray:
+    """Map a physical parameter value into the normalized space tsadar expects.
+
+    The logit diverges at the bounds and is nan outside them, so a value at or beyond
+    lb/ub yields a non-finite spectrum rather than an error. `check_bounds` guards the
+    apply endpoint against that.
+    """
+    shift, scale, inv_act = _norm[name]
+    normed = inv_act((jnp.asarray(physical, dtype=jnp.float64) - shift) / scale)
+    # ThomsonParams(num_params=1, batch=True) builds these as shape (1,); the diagnostic
+    # is evaluated with a trailing singleton axis, matching the previous implementation.
+    return normed.reshape(-1, 1)
+
+
+def check_bounds(inputs: "InputSchema") -> None:
+    """Raise if any input maps to a non-finite normalized value.
+
+    Tested via `to_normed` itself rather than by comparing against lb/ub, so the guard
+    cannot drift from the transform. Note the bounds are exclusive for an activated
+    parameter -- the logit is +-inf exactly at lb/ub -- but inclusive for one that is
+    not activated, where the transform is the identity.
+    """
+    for name, (lb, span, _) in _norm.items():
+        value = float(np.asarray(getattr(inputs, name)))
+        if not np.all(np.isfinite(np.asarray(to_normed(name, value)))):
+            raise ValueError(
+                f"{name}={value} does not map to a finite normalized value; it must lie "
+                f"within the deck bounds ({lb}, {lb + span})"
+            )
+
+
+def _describe(name: str, what: str) -> str:
+    lb, span, _ = _norm[name]
+    return f"{what} (physical units; deck bounds [{lb}, {lb + span}])"
 
 
 class InputSchema(BaseModel):
-    ne: Differentiable[Float64] = Field(description="electron density")
-    Te: Differentiable[Float64] = Field(description="electron temperature")
-    amp1: Differentiable[Float64] = Field(description="amplitude 1")
-    amp2: Differentiable[Float64] = Field(description="amplitude 2")
-    lam: Differentiable[Float64] = Field(description="central wavelength")
+    ne: Differentiable[Float64] = Field(description=_describe("ne", "electron density"))
+    Te: Differentiable[Float64] = Field(description=_describe("Te", "electron temperature"))
+    amp1: Differentiable[Float64] = Field(description=_describe("amp1", "amplitude 1"))
+    amp2: Differentiable[Float64] = Field(description=_describe("amp2", "amplitude 2"))
+    lam: Differentiable[Float64] = Field(description=_describe("lam", "central wavelength"))
 
 
 class OutputSchema(BaseModel):
     electron_spectrum: Differentiable[Array[(None,), Float64]] = Field(description="electron spectrum")
 
 
+@eqx.filter_jit
+def apply_jit(inputs: dict) -> dict:
+    # Scatter the exposed parameters into the parameter tree. Everything else in
+    # `ts_params` is closed over as a constant, so no partition/combine is needed and
+    # differentiability is decided solely by `Differentiable[...]` in InputSchema.
+    params = eqx.tree_at(
+        lambda p: (
+            p.electron.normed_ne,
+            p.electron.normed_Te,
+            p.general.normed_amp1,
+            p.general.normed_amp2,
+            p.general.normed_lam,
+        ),
+        ts_params,
+        replace=tuple(to_normed(name, inputs[name]) for name in PARAMS),
+    )
+    e_spec, _, _, _ = ts_diag(params, dummy_batch)
+    # Squeeze inside the jit so abstract_eval derives the same shape apply returns.
+    return {"electron_spectrum": jnp.squeeze(e_spec)}
+
+
 def apply(inputs: InputSchema) -> OutputSchema:
-    """Apply the model to the inputs and return the electron spectrum.
-
-    Args:
-        inputs: InputSchema
-
-    Returns:
-        OutputSchema
-    """
-    diff_params = initialize_thomson_params(inputs)
-    e_spec = ts_diag_wrapper(diff_params)
-    return OutputSchema(electron_spectrum=np.squeeze(e_spec))
+    check_bounds(inputs)
+    return OutputSchema(**jax_apply(apply_jit, inputs))
 
 
 def jacobian(inputs: InputSchema, jac_inputs: set[str], jac_outputs: set[str]):
-    _diff_params = initialize_thomson_params(inputs)
-    # Compute the Jacobian using the Thomson Scattering Diagnostic model as implemented in tsadar
-    jac = jac_fn(_diff_params)
+    return jax_jacobian(apply_jit, inputs, jac_inputs, jac_outputs)
 
-    jac_dict = {"electron_spectrum": {}}
-    for jax_input in jac_inputs:
-        if jax_input in ["ne", "Te"]:
-            jac_dict["electron_spectrum"][jax_input] = np.squeeze(getattr(jac.electron, f"normed_{jax_input}"))
 
-        elif jax_input in ["amp1", "amp2", "lam"]:
-            jac_dict["electron_spectrum"][jax_input] = np.squeeze(getattr(jac.general, f"normed_{jax_input}"))
+def jacobian_vector_product(
+    inputs: InputSchema,
+    jvp_inputs: set[str],
+    jvp_outputs: set[str],
+    tangent_vector: dict[str, Any],
+):
+    return jax_jvp(apply_jit, inputs, jvp_inputs, jvp_outputs, tangent_vector)
 
-        else:
-            raise ValueError(f"Unknown input: {jax_input}")
 
-    return jac_dict
+def vector_jacobian_product(
+    inputs: InputSchema,
+    vjp_inputs: set[str],
+    vjp_outputs: set[str],
+    cotangent_vector: dict[str, Any],
+):
+    return jax_vjp(apply_jit, inputs, vjp_inputs, vjp_outputs, cotangent_vector)
 
 
 def abstract_eval(abstract_inputs):
-    return {"electron_spectrum": ShapeDType(shape=(1024), dtype="float64")}
+    return jax_abstract_eval(apply_jit, abstract_inputs)

--- a/tsadar_gui/tesseract_ui.py
+++ b/tsadar_gui/tesseract_ui.py
@@ -1,88 +1,157 @@
-from jax import config as jax_config
-
-
-jax_config.update("jax_enable_x64", True)
-
-import numpy as np
 import boto3
-
-
-import tqdm, optax, equinox as eqx, yaml
+import numpy as np
+import optax
 import plotly.graph_objects as go
+import requests
 import streamlit as st
-
-from tsadar import ThomsonParams
-from tsadar.core.modules.ts_params import get_filter_spec
-
-from flatten_dict import flatten, unflatten
-
+import tqdm
 
 from tesseract_core import Tesseract
 
 
-with open("./tesseract/1d-defaults.yaml", "r") as f:
-    defaults = yaml.safe_load(f)
+PARAMS = ["ne", "Te", "amp1", "amp2", "lam"]
+JAC_OUTPUTS = ["electron_spectrum"]
 
-with open("./tesseract/1d-inputs.yaml", "r") as f:
-    inputs = yaml.safe_load(f)
-
-defaults = flatten(defaults)
-defaults.update(flatten(inputs))
-config = unflatten(defaults)
-
-diff_wrt_to = ["ne", "Te", "amp1", "amp2", "lam"]
-jac_outputs = ["electron_spectrum"]
-
-
-def to_arr(x):
-    """Convert a float to a numpy array."""
-    return np.array(np.array(x, dtype=np.float64)).reshape(-1, 1)
-
-
-def to_numpy(x: dict[str, float]) -> np.ndarray:
-    """Convert the parameter dictionary to a numpy array."""
-    return np.concatenate([[x[k] for k in diff_wrt_to]])
+# Physically realistic OMEGA conditions, used to draw both the synthetic truth and the
+# initial guess. These are deliberately *not* the deck bounds: the bounds are validity
+# limits for the model, so sampling ne from the deck's (0.001, 1.0) would generate test
+# cases no experiment would produce. `check_sampling_ranges` asserts these sit strictly
+# inside the bounds the Tesseract declares, so a deck change cannot silently invalidate
+# them.
+SAMPLING_RANGES = {
+    "ne": (0.1, 0.7),  # 1e20 cm^-3
+    # Te and lam are inset from the deck's [0.001, 1.5] and [525, 527]. Those bounds are
+    # exclusive, and sampling hard against one puts the logit somewhere badly
+    # conditioned even when it does not land on the bound exactly.
+    "Te": (0.5, 1.4),  # keV
+    "amp1": (0.5, 2.5),
+    "amp2": (0.5, 2.5),
+    "lam": (525.2, 526.8),  # nm
+}
 
 
-def to_dict(params: np.ndarray) -> dict:
-    """Convert the numpy array to a parameter dictionary."""
-    return {k: params[i] for i, k in enumerate(diff_wrt_to)}
+@st.cache_data(ttl=3600)
+def fetch_bounds(tesseract_url: str) -> dict[str, tuple[float, float]]:
+    """Read each parameter's deck bounds off the Tesseract's OpenAPI document.
+
+    The bounds live in the tsadar deck and are declared on `InputSchema`, so this is the
+    only place the GUI learns them -- it does not keep its own copy to drift.
+
+    They are read by name rather than as JSON Schema constraints because pydantic puts
+    them on tesseract-core's encoded-array wrapper, which serialises them as `gt`/`lt`
+    (or `ge`/`le`) rather than as `exclusiveMinimum`/`exclusiveMaximum`.
+    """
+    response = requests.get(f"{tesseract_url}/openapi.json", timeout=10)
+    response.raise_for_status()
+    properties = response.json()["components"]["schemas"]["Apply_InputSchema"]["properties"]
+
+    bounds = {}
+    for name in PARAMS:
+        spec = properties[name]
+        lower = spec.get("gt", spec.get("ge"))
+        upper = spec.get("lt", spec.get("le"))
+        if lower is None or upper is None:
+            raise RuntimeError(
+                f"The Tesseract at {tesseract_url} does not declare bounds for {name!r}. "
+                "It predates the InputSchema that declares them; rebuild it."
+            )
+        bounds[name] = (lower, upper)
+    return bounds
+
+
+def check_sampling_ranges(bounds: dict[str, tuple[float, float]]) -> None:
+    """Fail loudly if the deck has moved out from under `SAMPLING_RANGES`."""
+    for name, (low, high) in SAMPLING_RANGES.items():
+        lower, upper = bounds[name]
+        if not lower < low < high < upper:
+            raise RuntimeError(
+                f"The sampling range for {name} {(low, high)} is not strictly inside the "
+                f"deck bounds {(lower, upper)}. Either the deck changed or the range is "
+                "wrong; both need a human."
+            )
+
+
+def sample_parameters(rng: np.random.Generator) -> dict[str, float]:
+    """Draw a physically plausible parameter set."""
+    return {name: float(rng.uniform(*SAMPLING_RANGES[name])) for name in PARAMS}
+
+
+# The Tesseract takes physical parameters and rejects anything outside the deck bounds,
+# so a plain gradient step on them would need projecting back into the box. We optimize
+# in an unconstrained space instead and map through a sigmoid, which keeps every iterate
+# strictly inside the bounds for free and is better conditioned near them. This is the
+# same reparameterization tsadar applies internally; it lives here now because the
+# Tesseract's own interface is physical.
+def to_unconstrained(
+    physical: dict[str, float], bounds: dict[str, tuple[float, float]]
+) -> dict[str, float]:
+    """Map physical parameters onto the whole real line via the logit."""
+    unconstrained = {}
+    for name, value in physical.items():
+        lower, upper = bounds[name]
+        fraction = (value - lower) / (upper - lower)
+        unconstrained[name] = float(np.log(fraction) - np.log1p(-fraction))
+    return unconstrained
+
+
+def to_physical(
+    unconstrained: dict[str, float], bounds: dict[str, tuple[float, float]]
+) -> dict[str, float]:
+    """Inverse of `to_unconstrained`.
+
+    The sigmoid keeps the result inside the bounds mathematically, but it saturates in
+    float64 for |u| above roughly 40, landing on the bound exactly -- which the Tesseract
+    rejects, since the bounds are exclusive. Pin the result one ULP inside so a long fit
+    that drives a parameter hard against a bound degrades instead of erroring.
+    """
+    physical = {}
+    for name, value in unconstrained.items():
+        lower, upper = bounds[name]
+        mapped = lower + (upper - lower) / (1.0 + np.exp(-value))
+        physical[name] = float(np.clip(mapped, np.nextafter(lower, upper), np.nextafter(upper, lower)))
+    return physical
+
+
+def dphysical_dunconstrained(
+    unconstrained: dict[str, float], bounds: dict[str, tuple[float, float]]
+) -> dict[str, float]:
+    """The chain-rule factor `span * sigmoid'(u)` relating the two spaces."""
+    factors = {}
+    for name, value in unconstrained.items():
+        lower, upper = bounds[name]
+        sigmoid = 1.0 / (1.0 + np.exp(-value))
+        factors[name] = (upper - lower) * sigmoid * (1.0 - sigmoid)
+    return factors
 
 
 def mse(pred: np.ndarray, true: np.ndarray) -> float:
     """Mean Squared Error."""
-    mse = np.mean(np.square(pred - true))
-    return mse
+    return float(np.mean(np.square(pred - true)))
 
 
-def grad_fn(parameters: np.ndarray, true_electron_spectrum: np.ndarray, tsadaract: Tesseract) -> np.ndarray:
-    """Compute the gradient of the MSE loss function with respect to the parameters."""
-    # Compute the gradient
+def evaluate(
+    unconstrained: dict[str, float],
+    true_electron_spectrum: np.ndarray,
+    tsadaract: Tesseract,
+    bounds: dict[str, tuple[float, float]],
+) -> tuple[np.ndarray, float, dict[str, float]]:
+    """One step's worth of work: the spectrum, the loss, and dloss/dunconstrained."""
+    physical = to_physical(unconstrained, bounds)
 
-    jacobian = tsadaract.jacobian(to_dict(parameters), diff_wrt_to, jac_outputs)["electron_spectrum"]
+    electron_spectrum = tsadaract.apply(physical)["electron_spectrum"]
+    jacobian = tsadaract.jacobian(physical, PARAMS, JAC_OUTPUTS)["electron_spectrum"]
 
-    # Compute the primal
-    electron_spectrum = tsadaract.apply(to_dict(parameters))["electron_spectrum"]
-
-    # Propagate the gradient through the model by differentiating the mse function
+    # Differentiate the MSE through the model, then through the reparameterization.
     error = electron_spectrum - true_electron_spectrum
-    grad = {}
-    for k in diff_wrt_to:
-        grad[k] = 2 * np.mean(jacobian[k] * error)
+    chain = dphysical_dunconstrained(unconstrained, bounds)
+    grad = {name: 2 * np.mean(jacobian[name] * error) * chain[name] for name in PARAMS}
 
-    return grad  # to_numpy(grad)
+    return electron_spectrum, mse(electron_spectrum, true_electron_spectrum), grad
 
 
-def create_parameter_dict(_ts_params: ThomsonParams) -> dict:
-    """Create a dictionary of parameters from the ThomsonParams object."""
-    parameters = {
-        "ne": _ts_params.electron.normed_ne[0],
-        "Te": _ts_params.electron.normed_Te[0],
-        "amp1": _ts_params.general.normed_amp1[0],
-        "amp2": _ts_params.general.normed_amp2[0],
-        "lam": _ts_params.general.normed_lam[0],
-    }
-    return parameters
+def display(parameters: dict[str, float]) -> dict[str, float]:
+    """Round parameters for display."""
+    return {name: round(float(value), 3) for name, value in parameters.items()}
 
 
 def tesseract_ui(tesseract_url):
@@ -121,57 +190,31 @@ def tesseract_ui(tesseract_url):
             st.success("Service stopped. Please refresh the page.")
 
         tsadaract = Tesseract(url=tesseract_url)
-        # Sample random true parameters
+        bounds = fetch_bounds(tesseract_url)
+        check_sampling_ranges(bounds)
+
         col1, col2 = st.columns(2)
 
+        # Sample the true parameters, and generate the synthetic spectrum to fit to.
         rng = np.random.default_rng()
-        true_ne = rng.uniform(0.1, 0.7)
-        true_Te = rng.uniform(0.5, 1.5)
-        true_amp1 = rng.uniform(0.5, 2.5)
-        true_amp2 = rng.uniform(0.5, 2.5)
-        true_lam = rng.uniform(525, 527)
-
-        config["parameters"]["electron"]["ne"]["val"] = true_ne
-        config["parameters"]["electron"]["Te"]["val"] = true_Te
-        config["parameters"]["general"]["amp1"]["val"] = true_amp1
-        config["parameters"]["general"]["amp2"]["val"] = true_amp2
-        config["parameters"]["general"]["lam"]["val"] = true_lam
-        true_ts_params = ThomsonParams(config["parameters"], num_params=1, batch=True, activate=True)
-
-        true_parameters = create_parameter_dict(true_ts_params)
+        true_parameters = sample_parameters(rng)
         true_electron_spectrum = tsadaract.apply(true_parameters)["electron_spectrum"]
-
-        true_fitted_params, _ = true_ts_params.get_fitted_params(config["parameters"])
 
         with col1:
             st.write("True parameters:")
-            st.json(clean_dict(true_fitted_params))
+            st.json(display(true_parameters))
 
-        # create an initial guess for the parameters
-        this_rng = np.random.default_rng()
-        init_ne = this_rng.uniform(0.1, 0.7)
-        init_Te = this_rng.uniform(0.5, 1.5)
-        init_amp1 = this_rng.uniform(0.5, 2.5)
-        init_amp2 = this_rng.uniform(0.5, 2.5)
-        init_lam = this_rng.uniform(525, 527)
-
-        config["parameters"]["electron"]["ne"]["val"] = init_ne
-        config["parameters"]["electron"]["Te"]["val"] = init_Te
-        config["parameters"]["general"]["amp1"]["val"] = init_amp1
-        config["parameters"]["general"]["amp2"]["val"] = init_amp2
-        config["parameters"]["general"]["lam"]["val"] = init_lam
-
-        fit_ts_params = ThomsonParams(config["parameters"], num_params=1, batch=True, activate=True)
-        fit_parameters = create_parameter_dict(fit_ts_params)
-        parameters_np = to_numpy(fit_parameters)
-
+        # Create an independent initial guess.
+        fit_parameters = sample_parameters(rng)
+        unconstrained = to_unconstrained(fit_parameters, bounds)
         electron_spectrum = tsadaract.apply(fit_parameters)["electron_spectrum"]
 
-        # plot true electron spectrum in a plotly chart in streamlit
         with col2:
-            st.write("Fitted parameters:")
+            st.write("Estimated parameters:")
             fit_param_holder = st.empty()
         fig_holder = st.empty()
+
+        fit_param_holder.json(display(fit_parameters))
 
         fig = go.Figure()
         fig.add_trace(go.Scatter(y=true_electron_spectrum, mode="lines+markers", name="True Electron Spectrum"))
@@ -181,29 +224,16 @@ def tesseract_ui(tesseract_url):
 
         learning_rate = st.number_input("Learning Rate", value=0.01, step=0.001, key="learning_rate")
         opt = optax.adam(learning_rate)
-
-        diff_params, static_params = eqx.partition(
-            fit_ts_params, filter_spec=get_filter_spec(cfg_params=config["parameters"], ts_params=fit_ts_params)
-        )
-        fit_parameters = create_parameter_dict(diff_params)
-        opt_state = opt.init(fit_parameters)
-
-        updated_fitted_parameters = get_fitted_params_for_ui(fit_parameters, diff_params, static_params)
-        fit_param_holder.write("Estimated parameters:")
-        fit_param_holder.json(updated_fitted_parameters)
+        opt_state = opt.init(unconstrained)
 
         if st.button("Fit"):
 
             for i in (pbar := tqdm.tqdm(range(1000))):
 
-                parameters_np = to_numpy(fit_parameters)
-                electron_spectrum = tsadaract.apply(fit_parameters)["electron_spectrum"]
-                loss, grad_loss = mse(electron_spectrum, true_electron_spectrum), grad_fn(
-                    parameters_np, true_electron_spectrum, tsadaract
-                )
+                electron_spectrum, loss, grad_loss = evaluate(unconstrained, true_electron_spectrum, tsadaract, bounds)
 
                 updates, opt_state = opt.update(grad_loss, opt_state)
-                fit_parameters = eqx.apply_updates(fit_parameters, updates)
+                unconstrained = optax.apply_updates(unconstrained, updates)
                 pbar.set_description(f"Loss: {loss:.4f}")
 
                 fig.data[1].y = electron_spectrum
@@ -213,27 +243,4 @@ def tesseract_ui(tesseract_url):
                 )
                 fig_holder.plotly_chart(fig)
 
-                fit_param_holder.write("Estimated parameters:")
-                updated_fitted_parameters = get_fitted_params_for_ui(fit_parameters, diff_params, static_params)
-                fit_param_holder.json(updated_fitted_parameters)
-
-
-def get_fitted_params_for_ui(fit_parameters, diff_params, static_params):
-    diff_params = eqx.tree_at(lambda x: x.electron.normed_ne, diff_params, to_arr(fit_parameters["ne"]))
-    diff_params = eqx.tree_at(lambda x: x.electron.normed_Te, diff_params, to_arr(fit_parameters["Te"]))
-    diff_params = eqx.tree_at(lambda x: x.general.normed_amp1, diff_params, to_arr(fit_parameters["amp1"]))
-    diff_params = eqx.tree_at(lambda x: x.general.normed_amp2, diff_params, to_arr(fit_parameters["amp2"]))
-    diff_params = eqx.tree_at(lambda x: x.general.normed_lam, diff_params, to_arr(fit_parameters["lam"]))
-    fit_ts_params = eqx.combine(diff_params, static_params)
-    updated_fitted_parameters, _ = fit_ts_params.get_fitted_params(config["parameters"])
-    updated_fitted_parameters = clean_dict(updated_fitted_parameters)
-    return updated_fitted_parameters
-
-
-def clean_dict(d: dict) -> dict:
-    for k, v in d.items():
-        if isinstance(v, dict):
-            d[k] = clean_dict(v)
-        else:
-            d[k] = round(float(np.squeeze(v)), 2)
-    return d
+                fit_param_holder.json(display(to_physical(unconstrained, bounds)))


### PR DESCRIPTION
Replaces the hand-rolled gradient endpoints in `tesseract/tesseract_api.py` with `tesseract_core.runtime.jax_recipes`, and changes the five exposed parameters from tsadar's internal normalized space to physical units. The deck bounds move onto the schema, and `tsadar_gui/tesseract_ui.py` — the one client of these endpoints — moves with them.

## Why the old structure existed

Not for the reason it looks like. `to_arr` used `np.array`, so `initialize_thomson_params` could only run on concrete values — outside `jit`. That one constraint forced everything else: `eqx.partition` + `get_filter_spec` to split the parameter tree, `eqx.combine` inside the jitted function, `jacrev` over the whole tree, and a manual demux from `jac.electron.normed_ne` back to `"ne"`.

Switching to `jnp.asarray` and moving the scatter inside `apply_jit` collapses the chain. `ts_params` is just closed over, and differentiability is decided by `Differentiable[...]` in `InputSchema` rather than by the deck's `active` flags.

## Also in here

- **Squeeze inside `apply_jit`**, so `jax_abstract_eval` derives the shape `apply` actually returns. Removes a hardcoded `ShapeDType(shape=(1024))` — which was also passing an `int`, not a tuple.
- **Adds `jacobian_vector_product` / `vector_jacobian_product`**, not previously exposed. With 5 scalar inputs and 1024 outputs, forward mode is ~5 passes against `jacrev`'s 1024.

## Physical inputs

Values were written straight into `normed_*`, and tsadar unnormalizes as `act_fun(normed) * scale + shift`. With `activate=True` and `active: True` the activation is a sigmoid, so **`ne=0.2` on the wire meant a physical ~0.55**, and the meaning of every input depended on the deck's `lb`/`ub` *and* on its `active` flags. Inputs are now physical, normalized internally.

This deliberately does **not** reuse tsadar's `inv_act_fun`. Its stabilized form `log(1e-2 + x/(1-x+1e-2))` is not the exact inverse of `sigmoid` — it round-trips the midpoint to `0.49759` rather than `0.5`, an error of ~0.24% of the parameter's span. We use the true logit so declared-physical inputs are honoured exactly.

> Side note worth its own issue: tsadar carries that same error internally. `ThomsonParams` stores `inv_act(val)` and unnormalizes with `act(normed)`, so the physical value tsadar uses is not quite the deck's `val` for any `active: True` parameter.

## Bounds live on the schema

The deck's `lb`/`ub` used to be enforced by a `check_bounds` helper called from `apply`, and communicated to clients as prose in each `Field` description. They are now declared as pydantic constraints on `InputSchema` instead, derived from the same `_norm` entries `to_normed` uses, so they still can't drift from the transform. Two things follow:

- **The guard covers every endpoint.** `jacobian`, `jacobian_vector_product` and `vector_jacobian_product` all take `InputSchema` and previously returned NaN for out-of-bounds input rather than erroring. Clients now get a 422.
- **The bounds are machine-readable**, so a client no longer has to keep its own copy.

`gt`/`lt` for an activated parameter, `ge`/`le` for one that is not — matching what `check_bounds` documented, since the logit is ±inf exactly at `lb`/`ub` while the identity transform is finite there.

> ⚠️ One wart, and the reason the bounds are still spelled out in each description: they serialize into the OpenAPI document as literal `gt`/`lt`, **not** as JSON Schema's `exclusiveMinimum`/`exclusiveMaximum`, because they land on tesseract-core's `EncodedArrayModel` wrapper rather than on a bare number. Plain `float` fields serialize correctly. Schema-driven tooling will therefore miss them — `tesseract_streamlit.parse` reads only `minimum`/`maximum`. Worth an upstream issue against tesseract-core.

## The GUI moves with it

`tsadar_gui/tesseract_ui.py` is the only client of these endpoints, and switching the wire format to physical units breaks it: `create_parameter_dict` read `normed_ne` / `normed_Te` / … straight off a `ThomsonParams` and posted those. Left alone, this branch would ship an interactive page that the new bounds reject outright. Fixing it deletes most of the module — `to_arr`, `to_numpy`, `to_dict`, `create_parameter_dict`, `get_fitted_params_for_ui` and `clean_dict` all go, along with the deck YAML it loaded and its jax / equinox / flatten_dict / tsadar imports. The GUI no longer needs tsadar importable to drive the Tesseract.

**The fit is now box-constrained where it used to be unconstrained.** The old code optimized the normalized values, and tsadar's sigmoid kept them inside the deck bounds for free. Rather than project each Adam step back into the box — which changes the algorithm and lets iterates stick to a boundary — the same reparameterization now lives in the client: optimize `u`, post `lb + span * sigmoid(u)`, and carry the returned Jacobian through the chain-rule factor `span * sigmoid'(u)`. The Tesseract's interface stays physical; the parameterization is the optimizer's business.

`to_physical` pins its result one ULP inside the bounds via `np.nextafter`. The sigmoid is exact in principle but saturates in float64 for `|u|` above roughly 40, landing on the bound itself — which the now-exclusive bounds reject. It is a degradation path, not a projection step; it only fires past saturation.

Bounds are read off the served OpenAPI document rather than hardcoded a third time. `SAMPLING_RANGES` is **kept**, because it is a different quantity: the deck bounds are validity limits, while these are physically plausible OMEGA conditions to draw a synthetic truth from, and sampling `ne` over the deck's `(0.001, 1.0)` would generate cases no experiment would produce. `check_sampling_ranges` asserts they sit strictly inside the declared bounds — it already caught `Te`, whose range ran to exactly the deck's exclusive upper bound of `1.5`. `Te` and `lam` are now inset.

Also halves the round trips per step: the loop called `apply` once for the plot and `grad_fn` called it again alongside `jacobian`. `evaluate` returns the spectrum, loss and gradient from one `apply` and one `jacobian`.

## Verification

Against tsadar at `b7ffc89` on its own `configs/1d` deck, at each parameter's deck-bound midpoint:

| check | result |
|---|---|
| physical → normed → tsadar's `get_unnormed_params` | `abs_err = 0.00e+00`, all five |
| new physical-input `apply` vs old normed-input implementation | `max|old − new| = 2.6e-14`, shape `(1024,)` both |
| all five gradients vs central differences (step-size sweep) | second-order convergence to ~1e-8 at optimal step |
| `apply` end-to-end | finite `(1024,)`; guard fires outside *and* exactly at `ub` |

Example sweep for `d/dlam`, showing clean second-order convergence to AD rather than agreement at one arbitrary step:

```
h=1e-2:5.0e+00  1e-3:2.3e-02  1e-4:2.2e-04  1e-5:2.2e-06  1e-6:1.0e-08  1e-7:2.5e-07(roundoff)
```

For the bounds and the client, against real `tesseract_core` pydantic models built with the deck's actual `lb`/`ub`:

| check | result |
|---|---|
| `InputSchema` rejects `lb`, `ub` and NaN, accepts the interior | all five, via the **encoded-array wire format**, not just the float shorthand |
| logit round trip `to_physical(to_unconstrained(x))` | `max abs err = 5.6e-17` |
| chain-rule factor `d(physical)/du` vs central differences | agreement to ~1e-8, the finite-difference floor |
| full `dloss/du` path vs central differences of the loss | agreement to ~1e-8, against a mock 1024-output model |
| `to_physical` at `\|u\|` ∈ {40, 50, 1e3, ∞} | strictly inside bounds, and accepted by `InputSchema` |

## Scope and caveats

- **`tesseract_api.py` goes 129 → 192 lines.** The recipe deletes the boilerplate, but physical-unit normalization and the two new endpoints add back more than it removes. The simplification is structural, not in lines. `tesseract_ui.py` is 239 → 246, but that is +149/−142 — a near-total rewrite, mostly deletion offset by comments.
- **No `tesseract build` has been run.** The tsadar-side numerics in the first table were exercised directly against tsadar with `tesseract_core` stubbed out; the bounds work in the second table used real `tesseract_core` models but not a live container. `tesseract_config.yaml` targets `linux/amd64`, so a build is emulated and slow on arm64. Worth doing before merge — it is the one gap.
- **Verified against tsadar `b7ffc89`, but this repo pins `v0.1.2`.** Every API this uses exists at v0.1.2 — `get_act_and_inv_act` (ts_params.py:183), `ThomsonScatteringDiagnostic(cfg, scattering_angles)`, `act_funs`/`normed_*`, and the three names exported from `tsadar/__init__.py` — and the tsadar-facing surface is otherwise unchanged from the code being replaced. The pin bump is the follow-up PR, which is stacked on this branch.
- `requirements.txt` gains `requests`, now a direct import in `tesseract_ui.py` for the OpenAPI fetch.
- `tesseract/1d-*.yaml` are untouched here.

## Follow-ups, not in scope

- `evaluate` uses `jacobian` (5 forward passes) where a single `vector_jacobian_product` would give the gradient of the scalar loss in one — a natural use for what this PR adds.
- The `gt`/`lt` serialization wart above, upstream against tesseract-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
