### PR TITLE
Browser backend: FastAPI read layer over the MLflow tracking server

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -1,0 +1,43 @@
+# Tests for the Thomson analysis browser backend (tsadar_browser).
+#
+# Deliberately minimal: ergodicio/tsadar-app#34 owns packaging and CI properly
+# (container build, /api/health smoke test, generated-client sync check) and
+# will extend or absorb this. It exists now so the backend is guarded on PRs
+# from the first merge rather than the last.
+name: browser tests
+
+on:
+  pull_request:
+    paths:
+      - "tsadar_browser/**"
+      - "tests/browser/**"
+      - "requirements-browser*.txt"
+      - ".github/workflows/browser-tests.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tsadar_browser/**"
+      - "tests/browser/**"
+      - "requirements-browser*.txt"
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-browser-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-browser-dev.txt
+
+      - name: Run tests
+        # The suite uses a fake MLflow client, so no credentials or network
+        # access are required.
+        run: python -m pytest tests/browser -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.venv/
+venv/
+
+# Local configuration and the artifact cache default location
+.env
+.tsadar-browser-cache/
+
+# Frontend build output (arrives with #31)
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
 # TSADAR GUI
+
+This repository holds the user-facing pieces of TSADAR, an open-source Thomson
+Scattering data analysis package:
+
+- **`tsadar_browser/`** — the analysis browser and visualizer: a read-only
+  FastAPI layer over the MLflow tracking server, with a React SPA to follow.
+  See [docs/browser.md](docs/browser.md) and the tracking issue
+  [#37](https://github.com/ergodicio/tsadar-app/issues/37).
+- **`tsadar_app.py` / `tsadar_gui/`** — the older Streamlit app (below). Note its
+  job-submission path targets retired infrastructure and the app is no longer
+  deployed; see [#35](https://github.com/ergodicio/tsadar-app/issues/35).
+- **`tesseract/`** — a [Tesseract](https://github.com/pasteurlabs/tesseract-core)
+  wrapping TSADAR's differentiable forward model (spectrum + Jacobian).
+
+## Streamlit app
+
 This is a streamlit app for TSADAR, an open-source Thomson Scattering data analysis package. 
 
 To run this app, install the requirements and then run

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -1,0 +1,151 @@
+# Thomson analysis browser — backend
+
+A read-only FastAPI layer over the MLflow tracking server. MLflow stays the
+source of truth: this service owns no database and never writes to it. Runs are
+immutable once terminal, so fetched artifacts are cached on disk indefinitely
+and evicted only to stay under a size cap.
+
+Tracking issue: [#37]. This document covers [#29]; the netCDF slicing endpoints
+that render interactive plots are [#30].
+
+## Running it locally
+
+```bash
+pip install -r requirements-browser-dev.txt
+
+export MLFLOW_TRACKING_URI=https://continuum.ergodic.io/experiments
+export MLFLOW_TRACKING_USERNAME=...   # Basic auth, backed by Cognito
+export MLFLOW_TRACKING_PASSWORD=...
+
+uvicorn tsadar_browser.app:app --reload --port 8000
+```
+
+Artifacts live in `s3://public-ergodic-continuum` and are read with ambient AWS
+credentials locally, or the task role in deployment. Interactive docs are at
+`/api/docs`; the schema the frontend client is generated from is at
+`/api/openapi.json`.
+
+Run the tests with `python -m pytest tests/browser`. They use a fake MLflow
+client, so no credentials and no network are needed.
+
+## Configuration
+
+All configuration is environment variables (a `.env` file also works).
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MLFLOW_TRACKING_URI` | `https://continuum.ergodic.io/experiments` | Tracking server |
+| `MLFLOW_TRACKING_USERNAME` | — | Basic auth user |
+| `MLFLOW_TRACKING_PASSWORD` | — | Basic auth password |
+| `CACHE_DIR` | `$TMPDIR/tsadar-browser-cache` | Artifact cache root |
+| `CACHE_MAX_GB` | `10` | Cache size cap; LRU eviction above it |
+| `CORS_ORIGINS` | `localhost:5173` | Vite dev origins; comma-separated, empty disables CORS |
+| `MAX_PAGE_SIZE` | `200` | Ceiling on `page_size` |
+| `MLFLOW_HTTP_REQUEST_TIMEOUT` | `15` | Per-request timeout, seconds |
+| `MLFLOW_HTTP_REQUEST_MAX_RETRIES` | `2` | Retries before giving up |
+| `MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR` | `1` | Retry backoff |
+| `HEALTH_PROBE_TTL_S` | `5` | How long a reachability probe is trusted |
+
+The MLflow variables keep their canonical names because the mlflow client reads
+them straight from the environment; values loaded from a `.env` file are exported
+back into `os.environ` at startup so the client sees them too.
+
+The HTTP timeout defaults are **deliberately much lower than MLflow's own**
+(120 seconds with 7 retries and a backoff factor of 2, which can block for
+minutes on a single unreachable call). Behind a load balancer that is
+indistinguishable from a hung task, so the browser bounds it to fail fast and
+report `degraded`. Setting any of these three variables explicitly wins over the
+defaults above.
+
+## Endpoints
+
+| Endpoint | Notes |
+| --- | --- |
+| `GET /api/health` | Liveness plus MLflow reachability and cache stats |
+| `GET /api/experiments` | Active experiments |
+| `GET /api/runs` | Filter, sort, paginate; see below |
+| `GET /api/runs/{run_id}` | Config tree, tags, metric summaries, artifact listing, manifest |
+| `GET /api/runs/{run_id}/metrics/{key}` | Full metric history for loss curves |
+| `GET /api/runs/{run_id}/artifacts/{path}` | Streaming passthrough with content type |
+
+### Notes on the contract
+
+**`/api/health` answers 200 even when MLflow is down.** It is the ALB target-group
+check; a degraded browser that can explain itself beats a task the load balancer
+keeps recycling. The `status` field (`ok` / `degraded`) carries the real verdict.
+
+**Pagination is by cursor, not page number.** MLflow's `search_runs` paginates by
+opaque token, so `/api/runs` accepts `page_token` and returns `next_page_token`
+(null on the last page). Offset paging would mean walking every preceding page on
+each request. This is a deliberate deviation from the `page=` parameter sketched
+in [#29].
+
+**Filters are translated to MLflow filter strings**, currently against `params.*`:
+
+| Query param | Becomes |
+| --- | --- |
+| `shot` | `params."data.shotnum" = '...'` |
+| `status` | `attributes.status = '...'` (MLflow lifecycle) |
+| `stage` | `tags."status" = '...'` (tsadar's own progress tag) |
+| `user` | `tags."mlflow.user" = '...'` |
+| `q` | `attributes.run_name LIKE '%...%'` |
+
+`status` and `stage` are genuinely different things and both are exposed. MLflow's
+lifecycle status is `RUNNING`/`FINISHED`/`FAILED`/`KILLED`; tsadar separately sets
+a `status` **tag** that tracks fit progress (`preprocessing` → `minimizing` →
+`postprocessing` → `plotting` → `completed`, see `tsadar/inverse/fitter.py`). A
+run can be `FINISHED` at the MLflow level while its tag says `completed`, and a
+crashed run can be `FAILED` with the tag stuck at `minimizing` — which is exactly
+the diagnostic a physicist wants. These move to canonical tags once
+[ergodicio/tsadar#115] lands; only the translation layer changes.
+
+MLflow's filter grammar has no escape sequence for a quote inside a string
+literal, so filter values containing `'`, `"` or `\` are rejected with a 400
+rather than being interpolated into a query that would mean something else.
+Sort keys are allowlisted for the same reason.
+
+**Sorting** accepts `created`, `name`, `status`, `shot`, `loss` (prefix with `-`
+for descending). Duration is *not* sortable: it is computed from start/end
+timestamps and MLflow cannot order by it.
+
+**`final_loss` reports which metric it came from.** tsadar logs several loss
+metrics whose names contain spaces — `overall loss`, `min loss`, `epoch loss`.
+The first present wins and `loss_key` names it, so the table never silently
+compares two different quantities. Because keys contain spaces, metric history
+paths arrive URL-encoded (`/metrics/overall%20loss`).
+
+**The config tree is reconstructed by round-tripping the flattening.**
+`tsadar.utils.misc.log_mlflow` flattens the config with a dot reducer before
+logging; `/api/runs/{run_id}` unflattens it back into `config`, re-parsing scalars
+as YAML so numbers, booleans and lists come back as themselves rather than
+strings (`"None"` is special-cased, since it is not a YAML null token). The raw
+flat params stay available as `config_flat`. If a run logged colliding dotted keys
+the tree is ill-defined, so `config` is left empty and
+`config_unflatten_error` explains why instead of the API guessing.
+
+**Artifact paths are untrusted.** A `..` segment is rejected outright; the
+resolved path is also checked to be inside the cache root. Absolute-looking paths
+are relativized rather than rejected — harmless once the leading slash is gone.
+
+## Caching
+
+Keyed `run_id/path`, which is also the on-disk layout, so the cache is
+inspectable with `ls`. Artifacts of terminal runs (`FINISHED`/`FAILED`/`KILLED`)
+are cached indefinitely; artifacts of a `RUNNING` run are re-fetched every time
+because they may still be rewritten. Downloads land in a scratch directory inside
+the cache root and are moved into place atomically, so an interrupted fetch never
+leaves a truncated entry. Concurrent requests for the same cold artifact share
+one download. Eviction is least-recently-used by mtime (bumped on each hit, since
+`atime` is unreliable on the `relatime` mounts containers usually get).
+
+## What this does not do
+
+No netCDF reading — that is [#30]. No writes of any kind, so no job submission;
+the Streamlit app's submit path targets retired infrastructure and is not
+resurrected here ([#35]).
+
+[#29]: https://github.com/ergodicio/tsadar-app/issues/29
+[#30]: https://github.com/ergodicio/tsadar-app/issues/30
+[#35]: https://github.com/ergodicio/tsadar-app/issues/35
+[#37]: https://github.com/ergodicio/tsadar-app/issues/37
+[ergodicio/tsadar#115]: https://github.com/ergodicio/tsadar/issues/115

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -8,6 +8,42 @@ and evicted only to stay under a size cap.
 Tracking issue: [#37]. This document covers [#29]; the netCDF slicing endpoints
 that render interactive plots are [#30].
 
+## Scope: 1D Thomson, not angular
+
+The browser targets **time-resolved (`Time (ps)`) and space-resolved / imaging
+(`Radius (μm)`) Thomson scattering** — the routine OMEGA analysis workflow.
+**Angularly-resolved Thomson (`spectype: angular` / `angular_full`) is out of
+scope**: it needs its own diagnostics and is a research tool rather than a
+production analysis path. See [#37].
+
+This constrains *supported views*, not visibility. Angular runs share the same
+experiments, so they stay listed and keep their PNG gallery; what they must never
+do is render through a 1D code path whose axes mean something else.
+
+`RunSummary.spectype` reports the logged spectrum type, but it is **a hint, not
+ground truth**: `misc.log_mlflow(config)` runs in `runner.run` *before*
+`fitter.fit`, and `loadData` overwrites `spectype` from the data file during
+`prepare` — so a deck saying `temporal` run against angular data logs
+`temporal`. Ground truth is the artifact shape:
+
+| Signal | 1D | Angular |
+| --- | --- | --- |
+| Dataset | `binary/ele_fit_and_data.nc`, `binary/ion_fit_and_data.nc` | `binary/fit_and_data.nc` |
+| Written by | `plotters.plot_ts_data` | `plotters.plot_data_angular` |
+| x coordinate | `Time (ps)` / `Radius (\mum)` | `Scattering angle (degrees)` |
+
+Both dataset kinds hold the same two variables (`fit`, `data`) with the same
+number of dimensions, so falling back to `fit_and_data.nc` when the `ele_`/`ion_`
+files are missing would silently serve angle-vs-wavelength data to a UI labelling
+its x-axis as time. [#30] treats it as recognized-but-unsupported instead.
+
+Note the spatial label is stored literally as `Radius (\mum)`, a raw LaTeX
+fragment from `load_ts_data.py`; it needs handling before display.
+
+For the same reason, no `spectype` **filter** is offered on `/api/runs`: filtering
+on a value that can disagree with reality would quietly drop runs. The field is
+returned for display, and type is confirmed from artifacts on the detail path.
+
 ## Running it locally
 
 ```bash

--- a/requirements-browser-dev.txt
+++ b/requirements-browser-dev.txt
@@ -1,0 +1,3 @@
+-r requirements-browser.txt
+pytest
+httpx

--- a/requirements-browser.txt
+++ b/requirements-browser.txt
@@ -1,0 +1,14 @@
+# Backend for the Thomson analysis browser (tsadar_browser).
+#
+# Deliberately separate from requirements.txt: the Streamlit app pins
+# tsadar@v0.1.2 and pulls in JAX, none of which the read-only browser needs.
+# The full mlflow package (not mlflow-skinny) is required for the S3 artifact
+# repository used to fetch artifacts from s3://public-ergodic-continuum.
+fastapi
+uvicorn[standard]
+pydantic>=2
+pydantic-settings>=2
+mlflow
+boto3
+flatten_dict
+PyYAML

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -40,6 +40,7 @@ SAMPLE_PARAMS = {
     "data.lineouts.type.ps": "ps",
     "mlflow.experiment": "inverse-thomson-scattering",
     "other.extraoptions.load_ion_spec": "False",
+    "other.extraoptions.spectype": "temporal",
     "other.refit_thresh": "5.0",
     "other.lamrangE": "[400, 700]",
     "parameters.electron.Te.val": "0.5",

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -1,0 +1,212 @@
+"""Fixtures for the browser backend tests.
+
+The tests run against a fake MLflow client rather than the live tracking server,
+so CI needs no credentials and no network. The fake mimics only the handful of
+``MlflowClient`` methods :mod:`tsadar_browser.gateway` actually calls.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+
+from tsadar_browser.app import create_app
+from tsadar_browser.cache import ArtifactCache
+from tsadar_browser.deps import get_gateway
+from tsadar_browser.gateway import MlflowGateway
+from tsadar_browser.settings import Settings
+
+
+def missing(message: str) -> MlflowException:
+    """Build a genuine 'does not exist' MlflowException.
+
+    MlflowException ignores a *string* error_code (it silently becomes
+    INTERNAL_ERROR), so the protobuf enum is the only way to produce an
+    exception that maps to a 404 the way the real server's does.
+    """
+    return MlflowException(message, error_code=RESOURCE_DOES_NOT_EXIST)
+
+
+# A realistic slice of what tsadar logs: flattened with a dot reducer, every
+# value stringified, and a shot number under data.shotnum.
+SAMPLE_PARAMS = {
+    "data.shotnum": "101675",
+    "data.lineouts.start": "800",
+    "data.lineouts.end": "940",
+    "data.lineouts.type.ps": "ps",
+    "mlflow.experiment": "inverse-thomson-scattering",
+    "other.extraoptions.load_ion_spec": "False",
+    "other.refit_thresh": "5.0",
+    "other.lamrangE": "[400, 700]",
+    "parameters.electron.Te.val": "0.5",
+    "parameters.electron.Te.active": "True",
+    "parameters.general.Va.angle": "None",
+}
+
+
+def make_run(
+    run_id="run-abc",
+    experiment_id="1",
+    run_name="test-run",
+    status="FINISHED",
+    params=None,
+    metrics=None,
+    tags=None,
+    start_time=1_700_000_000_000,
+    end_time=1_700_000_123_000,
+):
+    tags = {"mlflow.user": "archis", "mlflow.runName": run_name, "status": "completed", **(tags or {})}
+    return SimpleNamespace(
+        info=SimpleNamespace(
+            run_id=run_id,
+            experiment_id=experiment_id,
+            run_name=run_name,
+            status=status,
+            start_time=start_time,
+            end_time=end_time,
+            artifact_uri=f"s3://public-ergodic-continuum/{experiment_id}/{run_id}/artifacts",
+        ),
+        data=SimpleNamespace(
+            params=dict(SAMPLE_PARAMS if params is None else params),
+            metrics=dict({"overall loss": 12.5, "fit_time": 42.0} if metrics is None else metrics),
+            tags=tags,
+        ),
+    )
+
+
+class FakePagedList(list):
+    def __init__(self, items, token=None):
+        super().__init__(items)
+        self.token = token
+
+
+class FakeMlflowClient:
+    """Minimal stand-in for ``MlflowClient``."""
+
+    def __init__(self, runs=None, experiments=None, artifacts=None, artifact_files=None, fail=False):
+        self.runs = {run.info.run_id: run for run in (runs or [make_run()])}
+        self.experiments = experiments or [
+            SimpleNamespace(
+                experiment_id="1",
+                name="inverse-thomson-scattering",
+                artifact_location="s3://public-ergodic-continuum/1",
+                lifecycle_stage="active",
+                creation_time=1_700_000_000_000,
+                last_update_time=1_700_000_000_000,
+                tags={},
+            )
+        ]
+        # {run_id: {dir_path: [FileInfo-alikes]}}
+        self.artifacts = artifacts or {}
+        # {run_id: {artifact_path: bytes}}
+        self.artifact_files = artifact_files or {}
+        self.fail = fail
+        self.search_calls: list[dict] = []
+        self.metric_history: dict[tuple[str, str], list] = {}
+
+    def _guard(self):
+        if self.fail:
+            raise MlflowException("connection refused")
+
+    def search_experiments(self, view_type=None, max_results=None):
+        self._guard()
+        return self.experiments
+
+    def get_experiment(self, experiment_id):
+        self._guard()
+        for exp in self.experiments:
+            if exp.experiment_id == experiment_id:
+                return exp
+        raise missing(f"no experiment {experiment_id}")
+
+    def get_experiment_by_name(self, name):
+        self._guard()
+        return next((exp for exp in self.experiments if exp.name == name), None)
+
+    def search_runs(self, experiment_ids, filter_string="", run_view_type=None, max_results=50, order_by=None, page_token=None):
+        self._guard()
+        self.search_calls.append(
+            {
+                "experiment_ids": experiment_ids,
+                "filter_string": filter_string,
+                "max_results": max_results,
+                "order_by": order_by,
+                "page_token": page_token,
+            }
+        )
+        return FakePagedList(list(self.runs.values())[:max_results], token="next-cursor")
+
+    def get_run(self, run_id):
+        self._guard()
+        if run_id not in self.runs:
+            raise missing(f"no run {run_id}")
+        return self.runs[run_id]
+
+    def get_metric_history(self, run_id, key):
+        self._guard()
+        self.get_run(run_id)
+        return self.metric_history.get((run_id, key), [])
+
+    def list_artifacts(self, run_id, path=""):
+        self._guard()
+        return self.artifacts.get(run_id, {}).get(path, [])
+
+    def download_artifacts(self, run_id, path, dst_path):
+        self._guard()
+        payload = self.artifact_files.get(run_id, {}).get(path)
+        if payload is None:
+            raise missing(f"no artifact {path}")
+        target = Path(dst_path) / Path(path).name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+        return str(target)
+
+
+def file_info(path, is_dir=False, file_size=None):
+    return SimpleNamespace(path=path, is_dir=is_dir, file_size=file_size)
+
+
+@pytest.fixture
+def settings(tmp_path) -> Settings:
+    return Settings(
+        mlflow_tracking_uri="https://continuum.ergodic.io/experiments",
+        cache_dir=tmp_path / "cache",
+        cache_max_gb=0.001,
+        cors_origins=[],
+    )
+
+
+@pytest.fixture
+def cache(settings) -> ArtifactCache:
+    return ArtifactCache(root=settings.cache_dir, max_bytes=settings.cache_max_bytes)
+
+
+@pytest.fixture
+def fake_client() -> FakeMlflowClient:
+    return FakeMlflowClient()
+
+
+@pytest.fixture
+def gateway(settings, cache, fake_client) -> MlflowGateway:
+    return MlflowGateway(settings=settings, cache=cache, client=fake_client)
+
+
+@pytest.fixture
+def client(gateway) -> TestClient:
+    """A TestClient whose routes all resolve through the fake-backed gateway.
+
+    Overriding the gateway alone is enough: routes read settings and the
+    artifact cache off it rather than reaching for module-level singletons.
+    """
+    app = create_app()
+    app.dependency_overrides[get_gateway] = lambda: gateway
+    return TestClient(app)
+
+
+@pytest.fixture
+def manifest_bytes() -> bytes:
+    return json.dumps({"schema_version": 1, "datasets": ["binary/ele_fit_and_data.nc"]}).encode()

--- a/tests/browser/test_api.py
+++ b/tests/browser/test_api.py
@@ -1,0 +1,223 @@
+"""Endpoint tests -- the contract the generated TypeScript client depends on."""
+
+from types import SimpleNamespace
+
+from .conftest import file_info, make_run
+
+
+class TestHealth:
+    def test_ok_when_mlflow_reachable(self, client):
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        assert body["mlflow_reachable"] is True
+        assert body["mlflow_error"] is None
+        assert body["cache"]["max_bytes"] > 0
+
+    def test_degraded_but_still_200_when_mlflow_is_down(self, client, fake_client):
+        """The ALB health check must not kill a task just because MLflow is down."""
+        fake_client.fail = True
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "degraded"
+        assert body["mlflow_reachable"] is False
+        assert "connection refused" in body["mlflow_error"]
+
+    def test_probe_result_is_reused_within_its_ttl(self, client, gateway, fake_client):
+        """A polling load balancer must not mean one MLflow request per poll."""
+        assert client.get("/api/health").json()["status"] == "ok"
+        before = len(fake_client.search_calls)
+
+        fake_client.fail = True
+        assert client.get("/api/health").json()["status"] == "ok", "cached probe should still be trusted"
+        assert len(fake_client.search_calls) == before
+
+    def test_probe_is_rechecked_once_the_ttl_expires(self, client, gateway, fake_client):
+        assert client.get("/api/health").json()["status"] == "ok"
+        gateway.settings.health_probe_ttl_s = 0
+        fake_client.fail = True
+        assert client.get("/api/health").json()["status"] == "degraded"
+
+
+class TestExperiments:
+    def test_lists_experiments(self, client):
+        response = client.get("/api/experiments")
+        assert response.status_code == 200
+        experiments = response.json()["experiments"]
+        assert [exp["name"] for exp in experiments] == ["inverse-thomson-scattering"]
+
+    def test_bad_gateway_when_mlflow_is_down(self, client, fake_client):
+        fake_client.fail = True
+        assert client.get("/api/experiments").status_code == 502
+
+
+class TestListRuns:
+    def test_returns_rows_and_a_cursor(self, client):
+        response = client.get("/api/runs")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["next_page_token"] == "next-cursor"
+        row = body["runs"][0]
+        assert row["run_id"] == "run-abc"
+        assert row["shot"] == "101675"
+        assert row["experiment_name"] == "inverse-thomson-scattering"
+        assert row["final_loss"] == 12.5
+        assert row["duration_s"] == 123.0
+        assert row["user"] == "archis"
+
+    def test_filters_reach_mlflow_as_a_filter_string(self, client, fake_client):
+        client.get("/api/runs?shot=101675&status=FINISHED&user=archis")
+        assert fake_client.search_calls[-1]["filter_string"] == (
+            "params.\"data.shotnum\" = '101675' and "
+            "attributes.status = 'FINISHED' and "
+            "tags.\"mlflow.user\" = 'archis'"
+        )
+
+    def test_experiment_name_is_resolved_to_an_id(self, client, fake_client):
+        client.get("/api/runs?experiment=inverse-thomson-scattering")
+        assert fake_client.search_calls[-1]["experiment_ids"] == ["1"]
+
+    def test_unknown_experiment_is_a_400(self, client):
+        response = client.get("/api/runs?experiment=does-not-exist")
+        assert response.status_code == 400
+        assert "unknown experiment" in response.json()["detail"]
+
+    def test_sort_is_translated(self, client, fake_client):
+        client.get("/api/runs?sort=-loss")
+        assert fake_client.search_calls[-1]["order_by"] == ['metrics."overall loss" DESC']
+
+    def test_unsortable_field_is_a_400(self, client):
+        assert client.get("/api/runs?sort=nonsense").status_code == 400
+
+    def test_hostile_filter_value_is_a_400_not_a_query(self, client):
+        assert client.get("/api/runs?user=o'brien").status_code == 400
+
+    def test_page_size_is_capped(self, client, fake_client):
+        client.get("/api/runs?page_size=100000")
+        assert fake_client.search_calls[-1]["max_results"] == 200
+
+    def test_page_token_is_forwarded(self, client, fake_client):
+        client.get("/api/runs?page_token=abc123")
+        assert fake_client.search_calls[-1]["page_token"] == "abc123"
+
+
+class TestRunDetail:
+    def test_returns_config_tree_and_artifacts(self, client, fake_client):
+        fake_client.artifacts["run-abc"] = {
+            "": [file_info("plots", is_dir=True), file_info("config.yaml", file_size=120)],
+            "plots": [file_info("plots/fit_and_data.png", file_size=2048)],
+        }
+        response = client.get("/api/runs/run-abc")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["config"]["data"]["shotnum"] == 101675
+        assert body["config_flat"]["data.shotnum"] == "101675"
+        assert [a["path"] for a in body["artifacts"]] == ["plots", "plots/fit_and_data.png", "config.yaml"]
+        assert body["mlflow_run_url"].endswith("/#/experiments/1/runs/run-abc")
+
+    def test_missing_run_is_a_404(self, client):
+        response = client.get("/api/runs/nope")
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"]
+
+    def test_manifest_is_parsed_when_present(self, client, fake_client, manifest_bytes):
+        fake_client.artifacts["run-abc"] = {"": [file_info("manifest.json", file_size=len(manifest_bytes))]}
+        fake_client.artifact_files["run-abc"] = {"manifest.json": manifest_bytes}
+        body = client.get("/api/runs/run-abc").json()
+        assert body["manifest"] == {"schema_version": 1, "datasets": ["binary/ele_fit_and_data.nc"]}
+
+    def test_manifest_is_null_when_absent(self, client, fake_client):
+        fake_client.artifacts["run-abc"] = {"": [file_info("config.yaml", file_size=12)]}
+        assert client.get("/api/runs/run-abc").json()["manifest"] is None
+
+
+class TestMetricHistory:
+    def test_returns_points_sorted_by_step(self, client, fake_client):
+        fake_client.metric_history[("run-abc", "epoch loss")] = [
+            SimpleNamespace(step=2, value=5.0, timestamp=300),
+            SimpleNamespace(step=0, value=9.0, timestamp=100),
+            SimpleNamespace(step=1, value=7.0, timestamp=200),
+        ]
+        response = client.get("/api/runs/run-abc/metrics/epoch%20loss")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["key"] == "epoch loss"
+        assert [p["step"] for p in body["points"]] == [0, 1, 2]
+        assert [p["value"] for p in body["points"]] == [9.0, 7.0, 5.0]
+
+    def test_metric_keys_with_spaces_survive_url_encoding(self, client, fake_client):
+        """tsadar's loss metrics are named 'overall loss', 'min loss', ..."""
+        fake_client.metric_history[("run-abc", "overall loss")] = [
+            SimpleNamespace(step=0, value=12.5, timestamp=100)
+        ]
+        assert client.get("/api/runs/run-abc/metrics/overall%20loss").status_code == 200
+
+    def test_unknown_metric_is_a_404(self, client):
+        assert client.get("/api/runs/run-abc/metrics/no-such-metric").status_code == 404
+
+    def test_missing_run_is_a_404(self, client):
+        assert client.get("/api/runs/nope/metrics/epoch%20loss").status_code == 404
+
+
+class TestArtifactPassthrough:
+    def test_streams_a_png_with_its_content_type(self, client, fake_client):
+        payload = b"\x89PNG\r\n\x1a\n" + b"0" * 64
+        fake_client.artifact_files["run-abc"] = {"plots/fit_and_data.png": payload}
+
+        response = client.get("/api/runs/run-abc/artifacts/plots/fit_and_data.png")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        assert response.content == payload
+
+    def test_netcdf_gets_a_useful_content_type(self, client, fake_client):
+        fake_client.artifact_files["run-abc"] = {"binary/ele_fit_and_data.nc": b"CDF\x01"}
+        response = client.get("/api/runs/run-abc/artifacts/binary/ele_fit_and_data.nc")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/x-netcdf"
+
+    def test_traversal_is_rejected(self, client):
+        response = client.get("/api/runs/run-abc/artifacts/../../etc/passwd")
+        assert response.status_code in (400, 404)
+        if response.status_code == 400:
+            assert "'..'" in response.json()["detail"]
+
+    def test_missing_artifact_is_a_404(self, client, fake_client):
+        fake_client.artifact_files["run-abc"] = {}
+        assert client.get("/api/runs/run-abc/artifacts/plots/absent.png").status_code == 404
+
+    def test_second_request_is_served_from_cache(self, client, fake_client, gateway):
+        fake_client.artifact_files["run-abc"] = {"config.yaml": b"data:\n  shotnum: 101675\n"}
+
+        assert client.get("/api/runs/run-abc/artifacts/config.yaml").status_code == 200
+        cached = gateway.cache.get("run-abc", "config.yaml")
+        assert cached is not None and cached.read_bytes().startswith(b"data:")
+
+        # Break the client: a cache hit must not need it.
+        fake_client.artifact_files["run-abc"] = {}
+        assert client.get("/api/runs/run-abc/artifacts/config.yaml").status_code == 200
+
+    def test_running_run_artifacts_are_not_cached(self, client, fake_client):
+        fake_client.runs["run-live"] = make_run(run_id="run-live", status="RUNNING", end_time=None)
+        fake_client.artifact_files["run-live"] = {"config.yaml": b"first"}
+        assert client.get("/api/runs/run-live/artifacts/config.yaml").content == b"first"
+
+        fake_client.artifact_files["run-live"] = {"config.yaml": b"second"}
+        assert client.get("/api/runs/run-live/artifacts/config.yaml").content == b"second"
+
+
+class TestOpenApi:
+    def test_schema_is_served_and_covers_every_endpoint(self, client):
+        """The frontend client is generated from this; #29 requires it stay honest."""
+        response = client.get("/api/openapi.json")
+        assert response.status_code == 200
+        paths = response.json()["paths"]
+        assert set(paths) == {
+            "/api/health",
+            "/api/experiments",
+            "/api/runs",
+            "/api/runs/{run_id}",
+            "/api/runs/{run_id}/metrics/{key}",
+            "/api/runs/{run_id}/artifacts/{artifact_path}",
+        }

--- a/tests/browser/test_cache.py
+++ b/tests/browser/test_cache.py
@@ -1,0 +1,122 @@
+"""Artifact cache: path safety, hits, and LRU eviction."""
+
+import os
+import time
+
+import pytest
+
+from tsadar_browser.cache import ArtifactCache, UnsafeArtifactPath, sanitize_artifact_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../../etc/passwd",
+        "binary/../../../etc/passwd",
+        "..",
+        "",
+        "   ",
+        "C:/windows/system32",
+        "..\\..\\windows",
+    ],
+)
+def test_sanitize_rejects_traversal(path):
+    with pytest.raises(UnsafeArtifactPath):
+        sanitize_artifact_path(path)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("plots/fit_and_data.png", "plots/fit_and_data.png"),
+        ("/binary/ele_fit_and_data.nc", "binary/ele_fit_and_data.nc"),
+        ("./csv/learned_parameters.csv", "csv/learned_parameters.csv"),
+        ("a//b///c.txt", "a/b/c.txt"),
+        # An absolute-looking path is relativized, not rejected: it cannot
+        # escape the cache root once the leading slash is gone.
+        ("/etc/passwd", "etc/passwd"),
+    ],
+)
+def test_sanitize_normalizes(path, expected):
+    assert sanitize_artifact_path(path) == expected
+
+
+def test_relativized_absolute_path_stays_inside_the_cache_root(cache):
+    resolved = cache.path_for("run-1", "/etc/passwd")
+    assert resolved.is_relative_to(cache.root.resolve())
+
+
+def test_path_for_rejects_multi_segment_run_id(cache):
+    with pytest.raises(UnsafeArtifactPath):
+        cache.path_for("run/../other", "plots/a.png")
+
+
+def test_fetch_caches_then_hits(cache):
+    calls = []
+
+    def downloader(scratch):
+        calls.append(scratch)
+        target = scratch / "a.png"
+        target.write_bytes(b"payload")
+        return target
+
+    first = cache.fetch("run-1", "plots/a.png", downloader, cacheable=True)
+    assert first.read_bytes() == b"payload"
+    assert len(calls) == 1
+
+    second = cache.fetch("run-1", "plots/a.png", downloader, cacheable=True)
+    assert second == first
+    assert len(calls) == 1, "a cached artifact must not be re-downloaded"
+
+
+def test_fetch_does_not_cache_non_terminal_runs(cache):
+    """A running run may still rewrite its artifacts, so every read re-fetches."""
+    calls = []
+
+    def downloader(scratch):
+        calls.append(1)
+        target = scratch / "a.png"
+        target.write_bytes(b"v%d" % len(calls))
+        return target
+
+    cache.fetch("run-1", "plots/a.png", downloader, cacheable=False)
+    result = cache.fetch("run-1", "plots/a.png", downloader, cacheable=False)
+    assert len(calls) == 2
+    assert result.read_bytes() == b"v2"
+
+
+def test_fetch_raises_when_downloader_produces_nothing(cache):
+    with pytest.raises(FileNotFoundError):
+        cache.fetch("run-1", "plots/a.png", lambda scratch: scratch / "missing.png", cacheable=True)
+
+
+def test_eviction_removes_least_recently_used_first(tmp_path):
+    cache = ArtifactCache(root=tmp_path / "cache", max_bytes=300)
+
+    def write(name, payload):
+        def downloader(scratch):
+            target = scratch / name
+            target.write_bytes(payload)
+            return target
+
+        return cache.fetch("run-1", name, downloader, cacheable=True)
+
+    old = write("old.bin", b"x" * 200)
+    # Age the first entry so mtime ordering is unambiguous.
+    past = time.time() - 600
+    os.utime(old, (past, past))
+
+    new = write("new.bin", b"y" * 200)
+
+    assert not old.exists(), "the oldest entry should have been evicted"
+    assert new.exists()
+
+    entries, total = cache.stats()
+    assert entries == 1
+    assert total <= 300
+
+
+def test_stats_on_missing_root(tmp_path):
+    cache = ArtifactCache(root=tmp_path / "absent", max_bytes=100)
+    assert cache.stats() == (0, 0)
+    assert cache.evict_if_needed() == 0

--- a/tests/browser/test_gateway.py
+++ b/tests/browser/test_gateway.py
@@ -117,6 +117,32 @@ class TestSummaries:
         detail = gateway.get_run("run-noloss")
         assert detail.loss_key is None and detail.final_loss is None
 
+    def test_spectype_is_reported(self, settings, cache, fake_client):
+        from .conftest import SAMPLE_PARAMS
+
+        fake_client.runs["run-temporal"] = make_run(
+            run_id="run-temporal",
+            params={**SAMPLE_PARAMS, "other.extraoptions.spectype": "temporal"},
+        )
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+        assert gateway.get_run("run-temporal").spectype == "temporal"
+
+    def test_angular_spectype_is_reported_not_suppressed(self, settings, cache, fake_client):
+        """Angular runs stay listed (issue #37); only interactive views are out of scope."""
+        from .conftest import SAMPLE_PARAMS
+
+        fake_client.runs["run-ang"] = make_run(
+            run_id="run-ang",
+            params={**SAMPLE_PARAMS, "other.extraoptions.spectype": "angular_full"},
+        )
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+        assert gateway.get_run("run-ang").spectype == "angular_full"
+
+    def test_spectype_is_null_when_not_logged(self, settings, cache, fake_client):
+        fake_client.runs["run-bare"] = make_run(run_id="run-bare", params={"data.shotnum": "1"})
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+        assert gateway.get_run("run-bare").spectype is None
+
     def test_stage_tag_is_surfaced_separately_from_lifecycle_status(self, gateway):
         detail = gateway.get_run("run-abc")
         assert detail.status == "FINISHED"

--- a/tests/browser/test_gateway.py
+++ b/tests/browser/test_gateway.py
@@ -1,0 +1,155 @@
+"""Gateway unit tests: filter translation, sorting, and the config round-trip."""
+
+import pytest
+
+from tsadar_browser.gateway import InvalidQuery, MlflowGateway
+
+from .conftest import make_run
+
+
+class TestBuildFilter:
+    def test_empty_when_no_filters(self):
+        assert MlflowGateway.build_filter() == ""
+
+    def test_shot_targets_the_flattened_param(self):
+        assert MlflowGateway.build_filter(shot="101675") == "params.\"data.shotnum\" = '101675'"
+
+    def test_combines_clauses_with_and(self):
+        built = MlflowGateway.build_filter(shot="101675", status="finished", user="archis")
+        assert built == (
+            "params.\"data.shotnum\" = '101675' and "
+            "attributes.status = 'FINISHED' and "
+            "tags.\"mlflow.user\" = 'archis'"
+        )
+
+    def test_stage_uses_the_tsadar_status_tag(self):
+        assert MlflowGateway.build_filter(stage="minimizing") == "tags.\"status\" = 'minimizing'"
+
+    def test_free_text_becomes_a_like_on_run_name(self):
+        assert MlflowGateway.build_filter(q="scan") == "attributes.run_name LIKE '%scan%'"
+
+    def test_unknown_status_rejected(self):
+        with pytest.raises(InvalidQuery):
+            MlflowGateway.build_filter(status="not-a-status")
+
+    @pytest.mark.parametrize("hostile", ["o'brien", 'say "hi"', "back\\slash"])
+    def test_quotes_and_backslashes_rejected(self, hostile):
+        """MLflow's filter grammar cannot escape these, so they must not be interpolated."""
+        with pytest.raises(InvalidQuery):
+            MlflowGateway.build_filter(user=hostile)
+
+
+class TestBuildOrderBy:
+    def test_defaults_to_newest_first(self):
+        assert MlflowGateway.build_order_by(None) == ["attributes.start_time DESC"]
+
+    def test_ascending_and_descending(self):
+        assert MlflowGateway.build_order_by("name") == ["attributes.run_name ASC"]
+        assert MlflowGateway.build_order_by("-name") == ["attributes.run_name DESC"]
+
+    def test_loss_sorts_on_the_real_metric_name(self):
+        assert MlflowGateway.build_order_by("loss") == ['metrics."overall loss" ASC']
+
+    def test_unknown_sort_key_rejected(self):
+        with pytest.raises(InvalidQuery):
+            MlflowGateway.build_order_by("; drop table runs")
+
+
+class TestConfigRoundTrip:
+    def test_params_unflatten_into_a_nested_tree(self, gateway):
+        detail = gateway.get_run("run-abc")
+        assert detail.config["data"]["shotnum"] == 101675
+        assert detail.config["data"]["lineouts"]["start"] == 800
+        assert detail.config["data"]["lineouts"]["type"]["ps"] == "ps"
+        assert detail.config["parameters"]["electron"]["Te"]["val"] == 0.5
+
+    def test_types_are_recovered_not_left_as_strings(self, gateway):
+        config = gateway.get_run("run-abc").config
+        assert config["other"]["extraoptions"]["load_ion_spec"] is False
+        assert config["parameters"]["electron"]["Te"]["active"] is True
+        assert config["other"]["refit_thresh"] == 5.0
+        assert config["other"]["lamrangE"] == [400, 700]
+
+    def test_none_string_becomes_none(self, gateway):
+        """MLflow stores Python None as the literal 'None', which is not YAML null."""
+        assert gateway.get_run("run-abc").config["parameters"]["general"]["Va"]["angle"] is None
+
+    def test_flat_params_are_preserved_alongside_the_tree(self, gateway):
+        detail = gateway.get_run("run-abc")
+        assert detail.config_flat["data.shotnum"] == "101675"
+        assert detail.config_unflatten_error is None
+
+    def test_colliding_dotted_keys_report_an_error_instead_of_guessing(self, settings, cache, fake_client):
+        fake_client.runs["run-bad"] = make_run(
+            run_id="run-bad", params={"a.b": "1", "a.b.c": "2"}
+        )
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+
+        detail = gateway.get_run("run-bad")
+        assert detail.config == {}
+        assert detail.config_unflatten_error
+        assert detail.config_flat == {"a.b": "1", "a.b.c": "2"}
+
+
+class TestSummaries:
+    def test_duration_computed_from_timestamps(self, gateway):
+        assert gateway.get_run("run-abc").duration_s == pytest.approx(123.0)
+
+    def test_duration_is_null_while_running(self, settings, cache, fake_client):
+        fake_client.runs["run-live"] = make_run(run_id="run-live", status="RUNNING", end_time=None)
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+        assert gateway.get_run("run-live").duration_s is None
+
+    def test_loss_key_is_reported_alongside_the_value(self, gateway):
+        detail = gateway.get_run("run-abc")
+        assert detail.loss_key == "overall loss"
+        assert detail.final_loss == 12.5
+
+    def test_falls_back_through_the_loss_key_preference_order(self, settings, cache, fake_client):
+        fake_client.runs["run-min"] = make_run(run_id="run-min", metrics={"min loss": 3.0})
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+        detail = gateway.get_run("run-min")
+        assert (detail.loss_key, detail.final_loss) == ("min loss", 3.0)
+
+    def test_no_loss_metric_leaves_both_null(self, settings, cache, fake_client):
+        fake_client.runs["run-noloss"] = make_run(run_id="run-noloss", metrics={"fit_time": 1.0})
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+        detail = gateway.get_run("run-noloss")
+        assert detail.loss_key is None and detail.final_loss is None
+
+    def test_stage_tag_is_surfaced_separately_from_lifecycle_status(self, gateway):
+        detail = gateway.get_run("run-abc")
+        assert detail.status == "FINISHED"
+        assert detail.stage == "completed"
+
+    def test_run_url_deep_links_into_the_mlflow_ui(self, gateway):
+        detail = gateway.get_run("run-abc")
+        assert detail.mlflow_run_url == (
+            "https://continuum.ergodic.io/experiments/#/experiments/1/runs/run-abc"
+        )
+
+
+class TestArtifactListing:
+    def test_listing_recurses_into_directories(self, settings, cache, fake_client):
+        from .conftest import file_info
+
+        fake_client.artifacts["run-abc"] = {
+            "": [file_info("binary", is_dir=True), file_info("config.yaml", file_size=120)],
+            "binary": [file_info("binary/ele_fit_and_data.nc", file_size=4096)],
+        }
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+
+        # Depth-first: each directory is followed immediately by its contents,
+        # so the flat list still reads as a tree.
+        paths = [entry.path for entry in gateway.list_artifacts("run-abc")]
+        assert paths == ["binary", "binary/ele_fit_and_data.nc", "config.yaml"]
+
+        by_path = {entry.path: entry for entry in gateway.list_artifacts("run-abc")}
+        assert by_path["binary"].is_dir is True
+        assert by_path["binary/ele_fit_and_data.nc"].size == 4096
+
+    def test_unreadable_artifact_store_does_not_raise(self, settings, cache, fake_client):
+        """The run page must still render if S3 is unreachable."""
+        fake_client.fail = True
+        gateway = MlflowGateway(settings=settings, cache=cache, client=fake_client)
+        assert gateway.list_artifacts("run-abc") == []

--- a/tests/browser/test_settings.py
+++ b/tests/browser/test_settings.py
@@ -1,0 +1,65 @@
+"""Settings parsing and the environment handoff to the mlflow client."""
+
+import os
+
+from tsadar_browser.settings import Settings
+
+
+class TestCorsOrigins:
+    def test_accepts_comma_separated(self, monkeypatch):
+        """A task definition writes CORS_ORIGINS=a,b -- not a JSON array."""
+        monkeypatch.setenv("CORS_ORIGINS", "http://a.example, http://b.example")
+        assert Settings().cors_origins == ["http://a.example", "http://b.example"]
+
+    def test_empty_means_no_cors(self, monkeypatch):
+        monkeypatch.setenv("CORS_ORIGINS", "")
+        assert Settings().cors_origins == []
+
+    def test_accepts_a_real_list(self):
+        assert Settings(cors_origins=["http://a"]).cors_origins == ["http://a"]
+
+
+class TestCacheSizing:
+    def test_gb_converted_to_bytes(self):
+        assert Settings(cache_max_gb=2).cache_max_bytes == 2 * 1024**3
+
+
+class TestEnvironmentHandoff:
+    def test_exports_credentials_for_the_mlflow_client(self, monkeypatch):
+        monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
+        settings = Settings(
+            mlflow_tracking_uri="https://example.invalid/experiments",
+            mlflow_tracking_username="user",
+            mlflow_tracking_password="secret",
+        )
+        settings.apply_to_environment()
+        assert os.environ["MLFLOW_TRACKING_URI"] == "https://example.invalid/experiments"
+        assert os.environ["MLFLOW_TRACKING_USERNAME"] == "user"
+        assert os.environ["MLFLOW_TRACKING_PASSWORD"] == "secret"
+
+    def test_bounds_mlflow_http_retries(self, monkeypatch):
+        """MLflow defaults to 120s x 7 retries, which would hang the health check."""
+        for name in (
+            "MLFLOW_HTTP_REQUEST_TIMEOUT",
+            "MLFLOW_HTTP_REQUEST_MAX_RETRIES",
+            "MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        Settings().apply_to_environment()
+        assert int(os.environ["MLFLOW_HTTP_REQUEST_TIMEOUT"]) == 15
+        assert int(os.environ["MLFLOW_HTTP_REQUEST_MAX_RETRIES"]) == 2
+
+    def test_does_not_override_an_explicit_operator_setting(self, monkeypatch):
+        monkeypatch.setenv("MLFLOW_HTTP_REQUEST_TIMEOUT", "99")
+        Settings().apply_to_environment()
+        assert os.environ["MLFLOW_HTTP_REQUEST_TIMEOUT"] == "99"
+
+    def test_missing_credentials_are_not_exported_as_empty(self, monkeypatch):
+        monkeypatch.delenv("MLFLOW_TRACKING_USERNAME", raising=False)
+        Settings(mlflow_tracking_username=None).apply_to_environment()
+        assert "MLFLOW_TRACKING_USERNAME" not in os.environ
+
+    def test_ui_base_strips_trailing_slash(self):
+        settings = Settings(mlflow_tracking_uri="https://example.invalid/experiments/")
+        assert settings.mlflow_ui_base == "https://example.invalid/experiments"

--- a/tsadar_browser/__init__.py
+++ b/tsadar_browser/__init__.py
@@ -1,0 +1,14 @@
+"""Backend for the Thomson scattering analysis browser.
+
+A read-only FastAPI layer over the MLflow tracking server. Run it with::
+
+    uvicorn tsadar_browser.app:app --reload
+"""
+
+__all__ = ["create_app"]
+
+
+def create_app():  # pragma: no cover - thin re-export to avoid importing FastAPI at package import
+    from .app import create_app as _create_app
+
+    return _create_app()

--- a/tsadar_browser/app.py
+++ b/tsadar_browser/app.py
@@ -1,0 +1,55 @@
+"""FastAPI application for the Thomson analysis browser.
+
+The OpenAPI schema this app produces is the frontend contract -- the TypeScript
+client is generated from it -- so route signatures and response models are
+public API. See ``docs/browser.md``.
+"""
+
+import logging
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .routes import experiments, health, runs
+from .settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+DESCRIPTION = """
+Read layer over the MLflow tracking server for browsing Thomson scattering
+analysis runs. MLflow remains the source of truth; this service holds no
+database of its own and never writes to it.
+"""
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    settings.apply_to_environment()
+
+    app = FastAPI(
+        title="TSADAR analysis browser API",
+        description=DESCRIPTION,
+        version="0.1.0",
+        openapi_url="/api/openapi.json",
+        docs_url="/api/docs",
+        redoc_url=None,
+    )
+
+    if settings.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=settings.cors_origins,
+            allow_credentials=True,
+            allow_methods=["GET"],
+            allow_headers=["*"],
+        )
+
+    app.include_router(health.router, prefix="/api")
+    app.include_router(experiments.router, prefix="/api")
+    app.include_router(runs.router, prefix="/api")
+
+    logger.info("browser API configured against %s", settings.mlflow_tracking_uri)
+    return app
+
+
+app = create_app()

--- a/tsadar_browser/cache.py
+++ b/tsadar_browser/cache.py
@@ -1,0 +1,192 @@
+"""Disk cache for MLflow artifacts.
+
+A run is immutable once its MLflow status is terminal, so terminal-run
+artifacts are cached indefinitely and only evicted to stay under
+``CACHE_MAX_GB`` (least-recently-used first). Artifacts of a still-running run
+are fetched fresh every time -- they may still be rewritten.
+
+Cache keys are ``<run_id>/<artifact_path>``, which doubles as the on-disk
+layout, so the cache is inspectable with ``ls``.
+"""
+
+import logging
+import os
+import shutil
+import tempfile
+import threading
+from collections import defaultdict
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class UnsafeArtifactPath(ValueError):
+    """Raised for artifact paths that would escape the cache directory."""
+
+
+def sanitize_artifact_path(artifact_path: str) -> str:
+    """Validate an artifact path and return it normalized to forward slashes.
+
+    Artifact paths arrive from the URL, so they are untrusted. A ``..`` segment
+    is rejected outright -- that is the only construct that can escape the cache
+    root. A leading slash is merely stripped rather than rejected: once
+    relativized it lands harmlessly under the run's cache directory (and MLflow
+    will 404 it), so there is nothing to defend against.
+    """
+    if not artifact_path or not artifact_path.strip():
+        raise UnsafeArtifactPath("artifact path must not be empty")
+
+    normalized = artifact_path.replace("\\", "/").strip("/")
+    segments = [segment for segment in normalized.split("/") if segment not in ("", ".")]
+    if not segments:
+        raise UnsafeArtifactPath("artifact path must not be empty")
+
+    if any(segment == ".." for segment in segments):
+        raise UnsafeArtifactPath(f"artifact path must not contain '..': {artifact_path!r}")
+    if ":" in normalized:
+        raise UnsafeArtifactPath(f"artifact path must not contain a drive or scheme: {artifact_path!r}")
+
+    return "/".join(segments)
+
+
+class ArtifactCache:
+    """LRU-evicting disk cache keyed by ``run_id`` and artifact path."""
+
+    def __init__(self, root: Path, max_bytes: int):
+        self.root = Path(root)
+        self.max_bytes = max_bytes
+        self._global_lock = threading.Lock()
+        self._key_locks: dict[str, threading.Lock] = defaultdict(threading.Lock)
+
+    # -- layout ---------------------------------------------------------------
+
+    def path_for(self, run_id: str, artifact_path: str) -> Path:
+        """Absolute cache path for an artifact, with traversal guarded twice.
+
+        The sanitizer rejects ``..`` up front; the resolved-prefix check below
+        catches anything that still manages to escape (e.g. via a symlinked
+        cache root).
+        """
+        safe_run_id = sanitize_artifact_path(run_id)
+        if "/" in safe_run_id:
+            raise UnsafeArtifactPath(f"run id must be a single path segment: {run_id!r}")
+
+        candidate = (self.root / safe_run_id / sanitize_artifact_path(artifact_path)).resolve()
+        root = self.root.resolve()
+        if not candidate.is_relative_to(root):
+            raise UnsafeArtifactPath(f"artifact path escapes the cache root: {artifact_path!r}")
+        return candidate
+
+    # -- reads ----------------------------------------------------------------
+
+    def get(self, run_id: str, artifact_path: str) -> Path | None:
+        """Return the cached file, marking it recently used, or None on a miss."""
+        target = self.path_for(run_id, artifact_path)
+        if not target.is_file():
+            return None
+        # mtime is the recency signal for eviction: atime is unreliable on
+        # noatime/relatime mounts, which is the common container default.
+        try:
+            os.utime(target, None)
+        except OSError:  # pragma: no cover - best effort recency bump
+            logger.debug("could not bump mtime for %s", target)
+        return target
+
+    def fetch(
+        self,
+        run_id: str,
+        artifact_path: str,
+        downloader: Callable[[Path], Path],
+        cacheable: bool = True,
+    ) -> Path:
+        """Return a local path for an artifact, downloading it if necessary.
+
+        ``downloader`` is handed a scratch directory and must return the path of
+        the file it wrote there. The file is moved into place only once the
+        download is complete, so an interrupted fetch never leaves a truncated
+        cache entry behind. When ``cacheable`` is False (non-terminal run) the
+        artifact is re-downloaded every time -- it may still be rewritten.
+        """
+        target = self.path_for(run_id, artifact_path)
+
+        if cacheable:
+            hit = self.get(run_id, artifact_path)
+            if hit is not None:
+                return hit
+
+        # One download per key: concurrent requests for the same cold artifact
+        # would otherwise each pull the whole file from S3.
+        with self._global_lock:
+            key_lock = self._key_locks[f"{run_id}/{artifact_path}"]
+
+        with key_lock:
+            if cacheable:
+                hit = self.get(run_id, artifact_path)
+                if hit is not None:
+                    return hit
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # Stage inside the cache root so the final move is same-filesystem
+            # and therefore atomic.
+            with tempfile.TemporaryDirectory(dir=self.root) as scratch:
+                downloaded = Path(downloader(Path(scratch)))
+                if not downloaded.is_file():
+                    raise FileNotFoundError(f"downloader did not produce a file for {artifact_path!r}")
+                os.replace(downloaded, target)
+
+        if cacheable:
+            self.evict_if_needed()
+        return target
+
+    # -- eviction -------------------------------------------------------------
+
+    def _entries(self) -> list[tuple[Path, int, float]]:
+        entries: list[tuple[Path, int, float]] = []
+        if not self.root.exists():
+            return entries
+        for path in self.root.rglob("*"):
+            if path.is_file():
+                try:
+                    stat = path.stat()
+                except OSError:  # pragma: no cover - raced with eviction
+                    continue
+                entries.append((path, stat.st_size, stat.st_mtime))
+        return entries
+
+    def stats(self) -> tuple[int, int]:
+        """Return ``(entry_count, total_bytes)``."""
+        entries = self._entries()
+        return len(entries), sum(size for _, size, _ in entries)
+
+    def evict_if_needed(self) -> int:
+        """Delete least-recently-used files until under the size cap.
+
+        Returns the number of bytes freed. Deleting a file that is currently
+        being streamed is safe on POSIX -- the open descriptor keeps it alive
+        until the response finishes.
+        """
+        with self._global_lock:
+            entries = self._entries()
+            total = sum(size for _, size, _ in entries)
+            if total <= self.max_bytes:
+                return 0
+
+            freed = 0
+            for path, size, _ in sorted(entries, key=lambda item: item[2]):
+                try:
+                    path.unlink()
+                except OSError:  # pragma: no cover - raced with another evictor
+                    continue
+                freed += size
+                total -= size
+                if total <= self.max_bytes:
+                    break
+
+            logger.info("evicted %d bytes from artifact cache", freed)
+            return freed
+
+    def clear(self) -> None:
+        with self._global_lock:
+            if self.root.exists():
+                shutil.rmtree(self.root)

--- a/tsadar_browser/deps.py
+++ b/tsadar_browser/deps.py
@@ -1,0 +1,20 @@
+"""Shared singletons for the API routes."""
+
+from functools import lru_cache
+
+from .cache import ArtifactCache
+from .gateway import MlflowGateway
+from .settings import Settings, get_settings
+
+
+@lru_cache
+def get_cache() -> ArtifactCache:
+    settings = get_settings()
+    return ArtifactCache(root=settings.cache_dir, max_bytes=settings.cache_max_bytes)
+
+
+@lru_cache
+def get_gateway() -> MlflowGateway:
+    settings: Settings = get_settings()
+    settings.apply_to_environment()
+    return MlflowGateway(settings=settings, cache=get_cache())

--- a/tsadar_browser/gateway.py
+++ b/tsadar_browser/gateway.py
@@ -1,0 +1,380 @@
+"""Read-only gateway over the MLflow tracking server.
+
+MLflow is the database; this module is the only place that talks to it. It
+translates browser-shaped queries into MLflow ``search_runs`` filter strings and
+turns MLflow's entities into the response models in :mod:`.schemas`.
+
+Nothing here writes to MLflow.
+"""
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import flatten_dict
+import yaml
+from mlflow.entities import ViewType
+from mlflow.tracking import MlflowClient
+
+from .cache import ArtifactCache, sanitize_artifact_path
+from .schemas import (
+    ArtifactEntry,
+    Experiment,
+    MetricHistory,
+    MetricPoint,
+    MetricSummary,
+    RunDetail,
+    RunPage,
+    RunSummary,
+)
+from .settings import Settings
+
+logger = logging.getLogger(__name__)
+
+#: MLflow statuses after which a run's artifacts can never change.
+TERMINAL_STATUSES = frozenset({"FINISHED", "FAILED", "KILLED"})
+
+#: Param key holding the shot number. Flattened with a dot reducer by
+#: ``tsadar.utils.misc.log_mlflow``, so ``data.shotnum`` in the config tree.
+#: Switches to a tag once ergodicio/tsadar#115 lands.
+SHOT_PARAM = "data.shotnum"
+
+#: tsadar's own progress tag, distinct from the MLflow lifecycle status.
+STAGE_TAG = "status"
+
+#: Metric holding the headline loss, best first. tsadar logs several loss
+#: metrics and the names contain spaces (see tsadar/inverse/fitter.py).
+LOSS_KEYS = ("overall loss", "min loss", "epoch loss", "loss")
+
+#: Sort keys the API accepts, mapped to MLflow ``order_by`` expressions.
+#: Allowlisted rather than interpolated: these land in a query string.
+SORTABLE = {
+    "created": "attributes.start_time",
+    "start_time": "attributes.start_time",
+    "end_time": "attributes.end_time",
+    "name": "attributes.run_name",
+    "status": "attributes.status",
+    "shot": f'params."{SHOT_PARAM}"',
+    "loss": f'metrics."{LOSS_KEYS[0]}"',
+}
+
+
+class MlflowUnavailable(RuntimeError):
+    """The tracking server could not be reached."""
+
+
+class InvalidQuery(ValueError):
+    """A caller-supplied filter or sort value was rejected."""
+
+
+def _quote(value: str) -> str:
+    """Render a value as an MLflow filter string literal.
+
+    MLflow's filter grammar has no escape sequence for a single quote inside a
+    quoted literal, so a value containing one is rejected rather than silently
+    mangled into a different query.
+    """
+    if "'" in value or '"' in value:
+        raise InvalidQuery(f"filter values must not contain quotes: {value!r}")
+    if "\\" in value:
+        raise InvalidQuery(f"filter values must not contain backslashes: {value!r}")
+    return f"'{value}'"
+
+
+def _coerce_param(raw: str) -> Any:
+    """Best-effort reversal of MLflow's stringification of a config value.
+
+    Params originate as YAML, so YAML is the right parser to get numbers,
+    booleans and lists back. ``str(None)`` is handled separately because
+    ``"None"`` is not a YAML null token.
+    """
+    if raw == "None":
+        return None
+    try:
+        return yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return raw
+
+
+class MlflowGateway:
+    def __init__(self, settings: Settings, cache: ArtifactCache, client: MlflowClient | None = None):
+        self.settings = settings
+        self.cache = cache
+        self._client = client or MlflowClient(tracking_uri=settings.mlflow_tracking_uri)
+        self._experiment_names: dict[str, str] = {}
+        self._probe: tuple[float, str | None] | None = None
+
+    # -- experiments ----------------------------------------------------------
+
+    def list_experiments(self) -> list[Experiment]:
+        experiments = self._client.search_experiments(view_type=ViewType.ACTIVE_ONLY)
+        self._experiment_names = {exp.experiment_id: exp.name for exp in experiments}
+        return [
+            Experiment(
+                experiment_id=exp.experiment_id,
+                name=exp.name,
+                artifact_location=exp.artifact_location,
+                lifecycle_stage=exp.lifecycle_stage,
+                creation_time=exp.creation_time,
+                last_update_time=exp.last_update_time,
+                tags=dict(exp.tags or {}),
+            )
+            for exp in experiments
+        ]
+
+    def _experiment_name(self, experiment_id: str) -> str | None:
+        if experiment_id not in self._experiment_names:
+            try:
+                experiment = self._client.get_experiment(experiment_id)
+            except Exception:  # noqa: BLE001 - a missing experiment must not fail the row
+                logger.debug("could not resolve experiment %s", experiment_id)
+                return None
+            self._experiment_names[experiment_id] = experiment.name
+        return self._experiment_names.get(experiment_id)
+
+    def _resolve_experiment_ids(self, experiment: str | None) -> list[str]:
+        """Resolve an experiment name (or id) to the ids to search.
+
+        With no experiment given, every active experiment is searched -- MLflow's
+        client API has no 'all experiments' mode.
+        """
+        if experiment:
+            found = self._client.get_experiment_by_name(experiment)
+            if found is not None:
+                return [found.experiment_id]
+            # Tolerate an id being passed where a name is expected.
+            try:
+                return [self._client.get_experiment(experiment).experiment_id]
+            except Exception as exc:  # noqa: BLE001
+                raise InvalidQuery(f"unknown experiment: {experiment!r}") from exc
+
+        return [exp.experiment_id for exp in self._client.search_experiments(view_type=ViewType.ACTIVE_ONLY)]
+
+    # -- runs -----------------------------------------------------------------
+
+    @staticmethod
+    def build_filter(
+        shot: str | None = None,
+        status: str | None = None,
+        user: str | None = None,
+        stage: str | None = None,
+        q: str | None = None,
+    ) -> str:
+        """Translate browser filters into an MLflow filter string."""
+        clauses: list[str] = []
+
+        if shot:
+            clauses.append(f'params."{SHOT_PARAM}" = {_quote(shot)}')
+        if status:
+            normalized = status.upper()
+            if normalized not in TERMINAL_STATUSES | {"RUNNING", "SCHEDULED"}:
+                raise InvalidQuery(f"unknown status: {status!r}")
+            clauses.append(f"attributes.status = {_quote(normalized)}")
+        if user:
+            clauses.append(f'tags."mlflow.user" = {_quote(user)}')
+        if stage:
+            clauses.append(f'tags."{STAGE_TAG}" = {_quote(stage)}')
+        if q:
+            clauses.append(f"attributes.run_name LIKE {_quote(f'%{q}%')}")
+
+        return " and ".join(clauses)
+
+    @staticmethod
+    def build_order_by(sort: str | None) -> list[str]:
+        """Translate a ``field`` / ``-field`` sort key into MLflow order_by."""
+        if not sort:
+            return ["attributes.start_time DESC"]
+
+        descending = sort.startswith("-")
+        field = sort.lstrip("-")
+        if field not in SORTABLE:
+            raise InvalidQuery(f"cannot sort by {field!r}; sortable fields are {sorted(SORTABLE)}")
+        return [f"{SORTABLE[field]} {'DESC' if descending else 'ASC'}"]
+
+    def search_runs(
+        self,
+        experiment: str | None = None,
+        shot: str | None = None,
+        status: str | None = None,
+        user: str | None = None,
+        stage: str | None = None,
+        q: str | None = None,
+        sort: str | None = None,
+        page_size: int = 50,
+        page_token: str | None = None,
+    ) -> RunPage:
+        experiment_ids = self._resolve_experiment_ids(experiment)
+        if not experiment_ids:
+            return RunPage(runs=[], page_size=page_size, next_page_token=None)
+
+        paged = self._client.search_runs(
+            experiment_ids=experiment_ids,
+            filter_string=self.build_filter(shot=shot, status=status, user=user, stage=stage, q=q),
+            run_view_type=ViewType.ACTIVE_ONLY,
+            max_results=page_size,
+            order_by=self.build_order_by(sort),
+            page_token=page_token,
+        )
+
+        return RunPage(
+            runs=[self._summarize(run) for run in paged],
+            page_size=page_size,
+            next_page_token=getattr(paged, "token", None),
+        )
+
+    def _summarize(self, run: Any) -> RunSummary:
+        info, data = run.info, run.data
+        metrics = dict(data.metrics or {})
+        params = dict(data.params or {})
+        tags = dict(data.tags or {})
+
+        loss_key = next((key for key in LOSS_KEYS if key in metrics), None)
+
+        duration_s = None
+        if info.start_time and info.end_time:
+            duration_s = round((info.end_time - info.start_time) / 1000.0, 2)
+
+        return RunSummary(
+            run_id=info.run_id,
+            run_name=getattr(info, "run_name", None) or tags.get("mlflow.runName"),
+            experiment_id=info.experiment_id,
+            experiment_name=self._experiment_name(info.experiment_id),
+            status=info.status,
+            stage=tags.get(STAGE_TAG),
+            shot=params.get(SHOT_PARAM),
+            final_loss=metrics.get(loss_key) if loss_key else None,
+            loss_key=loss_key,
+            start_time=info.start_time,
+            end_time=info.end_time,
+            duration_s=duration_s,
+            user=tags.get("mlflow.user"),
+        )
+
+    def get_run(self, run_id: str) -> RunDetail:
+        run = self._client.get_run(run_id)
+        summary = self._summarize(run)
+        params = dict(run.data.params or {})
+
+        config, unflatten_error = self._unflatten_params(params)
+        artifacts = self.list_artifacts(run_id)
+
+        return RunDetail(
+            **summary.model_dump(),
+            artifact_uri=run.info.artifact_uri,
+            mlflow_run_url=self.run_url(run.info.experiment_id, run_id),
+            config=config,
+            config_flat=params,
+            config_unflatten_error=unflatten_error,
+            tags=dict(run.data.tags or {}),
+            metrics=[
+                MetricSummary(key=key, value=value) for key, value in sorted((run.data.metrics or {}).items())
+            ],
+            artifacts=artifacts,
+            manifest=self.read_manifest(run_id, artifacts),
+        )
+
+    @staticmethod
+    def _unflatten_params(params: dict[str, str]) -> tuple[dict[str, Any], str | None]:
+        """Rebuild the nested config tree from dot-flattened params.
+
+        Mirrors ``tsadar.utils.misc.log_mlflow``, which flattens with
+        ``reducer="dot"``. Colliding keys (a scalar at ``a.b`` alongside
+        ``a.b.c``) make the tree ill-defined; report that rather than guessing.
+        """
+        if not params:
+            return {}, None
+        coerced = {key: _coerce_param(value) for key, value in params.items()}
+        try:
+            return flatten_dict.unflatten(coerced, splitter="dot"), None
+        except Exception as exc:  # noqa: BLE001 - flatten_dict raises bare ValueError/TypeError
+            logger.warning("could not unflatten params into a config tree: %s", exc)
+            return {}, str(exc)
+
+    def run_url(self, experiment_id: str, run_id: str) -> str:
+        return f"{self.settings.mlflow_ui_base}/#/experiments/{experiment_id}/runs/{run_id}"
+
+    def get_metric_history(self, run_id: str, key: str) -> MetricHistory:
+        history = self._client.get_metric_history(run_id, key)
+        return MetricHistory(
+            key=key,
+            points=[
+                MetricPoint(step=metric.step, value=metric.value, timestamp=metric.timestamp)
+                for metric in sorted(history, key=lambda metric: (metric.step, metric.timestamp))
+            ],
+        )
+
+    # -- artifacts ------------------------------------------------------------
+
+    def list_artifacts(self, run_id: str, path: str = "") -> list[ArtifactEntry]:
+        """Recursively list a run's artifacts, flattened to file entries plus dirs."""
+        entries: list[ArtifactEntry] = []
+        try:
+            listing = self._client.list_artifacts(run_id, path)
+        except Exception as exc:  # noqa: BLE001 - an unreachable artifact store must not 500 the run page
+            logger.warning("could not list artifacts for run %s at %r: %s", run_id, path, exc)
+            return entries
+
+        for item in listing:
+            entries.append(ArtifactEntry(path=item.path, is_dir=item.is_dir, size=item.file_size))
+            if item.is_dir:
+                entries.extend(self.list_artifacts(run_id, item.path))
+        return entries
+
+    def read_manifest(self, run_id: str, artifacts: list[ArtifactEntry] | None = None) -> dict[str, Any] | None:
+        """Parse ``manifest.json`` if the run logged one (ergodicio/tsadar#116)."""
+        if artifacts is not None and not any(entry.path == "manifest.json" for entry in artifacts):
+            return None
+        try:
+            local = self.download_artifact(run_id, "manifest.json")
+            return json.loads(local.read_text())
+        except Exception as exc:  # noqa: BLE001 - absent or malformed manifest is expected pre-contract
+            logger.debug("no readable manifest.json for run %s: %s", run_id, exc)
+            return None
+
+    def is_terminal(self, run_id: str) -> bool:
+        try:
+            return self._client.get_run(run_id).info.status in TERMINAL_STATUSES
+        except Exception:  # noqa: BLE001
+            return False
+
+    def download_artifact(self, run_id: str, artifact_path: str, cacheable: bool | None = None) -> Path:
+        """Return a local path to an artifact, using the disk cache.
+
+        The frontend never sees S3: this is the only route to artifact bytes.
+        """
+        safe_path = sanitize_artifact_path(artifact_path)
+        if cacheable is None:
+            cacheable = self.is_terminal(run_id)
+
+        def download(scratch: Path) -> Path:
+            local = self._client.download_artifacts(run_id, safe_path, str(scratch))
+            return Path(local)
+
+        return self.cache.fetch(run_id, safe_path, download, cacheable=cacheable)
+
+    def ping(self) -> None:
+        """Raise :class:`MlflowUnavailable` if the tracking server is unreachable.
+
+        The result is remembered for ``health_probe_ttl_s`` so a load balancer
+        polling ``/api/health`` does not translate into one MLflow request per
+        poll. Request timeouts and retries are bounded by
+        :meth:`Settings.apply_to_environment`, so a hard failure surfaces in
+        seconds rather than minutes.
+        """
+        now = time.monotonic()
+        if self._probe is not None:
+            checked_at, error = self._probe
+            if now - checked_at < self.settings.health_probe_ttl_s:
+                if error is not None:
+                    raise MlflowUnavailable(error)
+                return
+
+        try:
+            self._client.search_experiments(max_results=1)
+        except Exception as exc:  # noqa: BLE001
+            self._probe = (now, str(exc))
+            raise MlflowUnavailable(str(exc)) from exc
+
+        self._probe = (now, None)

--- a/tsadar_browser/gateway.py
+++ b/tsadar_browser/gateway.py
@@ -41,6 +41,15 @@ TERMINAL_STATUSES = frozenset({"FINISHED", "FAILED", "KILLED"})
 #: Switches to a tag once ergodicio/tsadar#115 lands.
 SHOT_PARAM = "data.shotnum"
 
+#: Param key holding the spectrum type. Reported but *not* trusted -- see
+#: :attr:`schemas.RunSummary.spectype`.
+SPECTYPE_PARAM = "other.extraoptions.spectype"
+
+#: Spectrum types the browser supports interactive views for. Angular Thomson
+#: needs its own diagnostics and is out of scope (see issue #37); those runs are
+#: still listed and still get their PNG gallery.
+ONE_D_SPECTYPES = frozenset({"temporal", "imaging"})
+
 #: tsadar's own progress tag, distinct from the MLflow lifecycle status.
 STAGE_TAG = "status"
 
@@ -244,6 +253,7 @@ class MlflowGateway:
             status=info.status,
             stage=tags.get(STAGE_TAG),
             shot=params.get(SHOT_PARAM),
+            spectype=params.get(SPECTYPE_PARAM),
             final_loss=metrics.get(loss_key) if loss_key else None,
             loss_key=loss_key,
             start_time=info.start_time,

--- a/tsadar_browser/routes/__init__.py
+++ b/tsadar_browser/routes/__init__.py
@@ -1,0 +1,5 @@
+"""API routers."""
+
+from . import experiments, health, runs
+
+__all__ = ["experiments", "health", "runs"]

--- a/tsadar_browser/routes/experiments.py
+++ b/tsadar_browser/routes/experiments.py
@@ -1,0 +1,17 @@
+"""Experiment listing."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..deps import get_gateway
+from ..gateway import MlflowGateway
+from ..schemas import ExperimentList
+
+router = APIRouter(tags=["experiments"])
+
+
+@router.get("/experiments", response_model=ExperimentList, summary="List active experiments")
+def list_experiments(gateway: MlflowGateway = Depends(get_gateway)) -> ExperimentList:
+    try:
+        return ExperimentList(experiments=gateway.list_experiments())
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"MLflow tracking server error: {exc}") from exc

--- a/tsadar_browser/routes/health.py
+++ b/tsadar_browser/routes/health.py
@@ -1,0 +1,41 @@
+"""Health endpoint.
+
+Doubles as the ALB target-group check, so it must answer 200 even when MLflow
+is unreachable -- a degraded browser that can explain itself is more useful than
+a task the load balancer keeps killing. ``status`` carries the real verdict.
+"""
+
+from fastapi import APIRouter, Depends
+
+from ..deps import get_gateway
+from ..gateway import MlflowGateway, MlflowUnavailable
+from ..schemas import CacheStats, HealthResponse
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", response_model=HealthResponse, summary="Liveness and MLflow reachability")
+def health(gateway: MlflowGateway = Depends(get_gateway)) -> HealthResponse:
+    # Read both off the gateway so a single override in tests (and a single
+    # construction path in production) governs the whole request.
+    settings, cache = gateway.settings, gateway.cache
+
+    reachable, error = True, None
+    try:
+        gateway.ping()
+    except MlflowUnavailable as exc:
+        reachable, error = False, str(exc)
+
+    entries, total_bytes = cache.stats()
+    return HealthResponse(
+        status="ok" if reachable else "degraded",
+        mlflow_tracking_uri=settings.mlflow_tracking_uri,
+        mlflow_reachable=reachable,
+        mlflow_error=error,
+        cache=CacheStats(
+            directory=str(cache.root),
+            entries=entries,
+            bytes=total_bytes,
+            max_bytes=cache.max_bytes,
+        ),
+    )

--- a/tsadar_browser/routes/runs.py
+++ b/tsadar_browser/routes/runs.py
@@ -1,0 +1,132 @@
+"""Run listing, run detail, metric history, and artifact passthrough."""
+
+import logging
+import mimetypes
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+from mlflow.exceptions import MlflowException
+
+from ..cache import UnsafeArtifactPath
+from ..deps import get_gateway
+from ..gateway import SHOT_PARAM, InvalidQuery, MlflowGateway
+from ..schemas import MetricHistory, RunDetail, RunPage
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["runs"])
+
+#: Content types the stdlib does not know but the browser needs to serve.
+EXTRA_CONTENT_TYPES = {
+    ".nc": "application/x-netcdf",
+    ".yaml": "application/yaml",
+    ".yml": "application/yaml",
+}
+
+
+def _reraise(exc: MlflowException, what: str) -> HTTPException:
+    """Translate an MLflow error into the closest HTTP status.
+
+    MLflow already maps its error codes to HTTP statuses, so defer to that
+    rather than matching on error-code strings. Anything that is not clearly the
+    caller's fault becomes a 502: the failure is upstream, not here.
+    """
+    status = exc.get_http_status_code()
+    if status == 404:
+        return HTTPException(status_code=404, detail=f"{what} not found: {exc}")
+    if status in (400, 403):
+        return HTTPException(status_code=status, detail=str(exc))
+    return HTTPException(status_code=502, detail=f"MLflow tracking server error: {exc}")
+
+
+@router.get("/runs", response_model=RunPage, summary="Search runs")
+def list_runs(
+    gateway: Annotated[MlflowGateway, Depends(get_gateway)],
+    experiment: Annotated[str | None, Query(description="Experiment name (or id)")] = None,
+    shot: Annotated[str | None, Query(description=f'Shot number, matched against params."{SHOT_PARAM}"')] = None,
+    status: Annotated[
+        str | None, Query(description="MLflow lifecycle status: RUNNING, FINISHED, FAILED, KILLED")
+    ] = None,
+    stage: Annotated[str | None, Query(description="tsadar progress tag, e.g. 'minimizing', 'completed'")] = None,
+    user: Annotated[str | None, Query(description="Submitting user (mlflow.user tag)")] = None,
+    q: Annotated[str | None, Query(description="Free-text substring match on run name")] = None,
+    sort: Annotated[
+        str | None,
+        Query(description="Sort key; prefix with '-' for descending. One of created, name, status, shot, loss."),
+    ] = None,
+    page_size: Annotated[int, Query(ge=1, description="Rows per page")] = 50,
+    page_token: Annotated[
+        str | None, Query(description="Cursor from a previous response's next_page_token")
+    ] = None,
+) -> RunPage:
+    try:
+        return gateway.search_runs(
+            experiment=experiment,
+            shot=shot,
+            status=status,
+            stage=stage,
+            user=user,
+            q=q,
+            sort=sort,
+            page_size=min(page_size, gateway.settings.max_page_size),
+            page_token=page_token,
+        )
+    except InvalidQuery as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except MlflowException as exc:
+        raise _reraise(exc, "experiment") from exc
+
+
+@router.get("/runs/{run_id}", response_model=RunDetail, summary="Run detail with config tree and artifact listing")
+def get_run(run_id: str, gateway: Annotated[MlflowGateway, Depends(get_gateway)]) -> RunDetail:
+    try:
+        return gateway.get_run(run_id)
+    except MlflowException as exc:
+        raise _reraise(exc, "run") from exc
+
+
+@router.get(
+    "/runs/{run_id}/metrics/{key:path}",
+    response_model=MetricHistory,
+    summary="Full metric history (loss curves)",
+)
+def get_metric_history(
+    run_id: str, key: str, gateway: Annotated[MlflowGateway, Depends(get_gateway)]
+) -> MetricHistory:
+    """Metric keys contain spaces (``overall loss``), so they arrive URL-encoded."""
+    try:
+        history = gateway.get_metric_history(run_id, key)
+    except MlflowException as exc:
+        raise _reraise(exc, "run") from exc
+
+    if not history.points:
+        raise HTTPException(status_code=404, detail=f"no metric history for key {key!r} on run {run_id}")
+    return history
+
+
+@router.get(
+    "/runs/{run_id}/artifacts/{artifact_path:path}",
+    summary="Stream an artifact",
+    response_class=FileResponse,
+    responses={200: {"content": {"application/octet-stream": {}}, "description": "Artifact bytes"}},
+)
+def get_artifact(
+    run_id: str, artifact_path: str, gateway: Annotated[MlflowGateway, Depends(get_gateway)]
+) -> FileResponse:
+    """Serve artifact bytes through the API so the frontend needs no S3 credentials."""
+    try:
+        local = gateway.download_artifact(run_id, artifact_path)
+    except UnsafeArtifactPath as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except MlflowException as exc:
+        raise _reraise(exc, "artifact") from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"artifact not found: {artifact_path}") from exc
+    except OSError as exc:
+        logger.warning("could not fetch artifact %s/%s: %s", run_id, artifact_path, exc)
+        raise HTTPException(status_code=502, detail=f"could not fetch artifact: {exc}") from exc
+
+    suffix = local.suffix.lower()
+    media_type = EXTRA_CONTENT_TYPES.get(suffix) or mimetypes.guess_type(local.name)[0] or "application/octet-stream"
+    return FileResponse(local, media_type=media_type, filename=local.name)

--- a/tsadar_browser/schemas.py
+++ b/tsadar_browser/schemas.py
@@ -1,0 +1,122 @@
+"""Response models for ``/api``.
+
+These models *are* the frontend contract: the generated TypeScript client comes
+from the OpenAPI schema FastAPI derives from them, so field names and
+optionality here are load-bearing. Prefer adding an optional field over
+changing the meaning of an existing one.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CacheStats(BaseModel):
+    directory: str
+    entries: int
+    bytes: int
+    max_bytes: int
+
+
+class HealthResponse(BaseModel):
+    status: str = Field(description="'ok' when MLflow is reachable, 'degraded' otherwise")
+    mlflow_tracking_uri: str
+    mlflow_reachable: bool
+    mlflow_error: str | None = Field(default=None, description="Why the tracking server could not be reached")
+    cache: CacheStats
+
+
+class Experiment(BaseModel):
+    experiment_id: str
+    name: str
+    artifact_location: str | None = None
+    lifecycle_stage: str | None = None
+    creation_time: int | None = Field(default=None, description="Unix epoch milliseconds")
+    last_update_time: int | None = Field(default=None, description="Unix epoch milliseconds")
+    tags: dict[str, str] = {}
+
+
+class ExperimentList(BaseModel):
+    experiments: list[Experiment]
+
+
+class RunSummary(BaseModel):
+    """One row of the run browser table."""
+
+    run_id: str
+    run_name: str | None = None
+    experiment_id: str
+    experiment_name: str | None = None
+    status: str | None = Field(default=None, description="MLflow lifecycle status: RUNNING/FINISHED/FAILED/KILLED")
+    stage: str | None = Field(
+        default=None,
+        description="tsadar's own progress tag ('preprocessing', 'minimizing', ... 'completed'), when logged",
+    )
+    shot: str | None = Field(default=None, description="Shot number, from the data.shotnum param")
+    final_loss: float | None = None
+    loss_key: str | None = Field(default=None, description="Which metric final_loss was read from")
+    start_time: int | None = Field(default=None, description="Unix epoch milliseconds")
+    end_time: int | None = Field(default=None, description="Unix epoch milliseconds")
+    duration_s: float | None = Field(default=None, description="Computed from start/end time; null while running")
+    user: str | None = None
+
+
+class RunPage(BaseModel):
+    runs: list[RunSummary]
+    page_size: int
+    next_page_token: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. MLflow paginates by token, not offset; null means last page.",
+    )
+
+
+class MetricSummary(BaseModel):
+    key: str
+    value: float
+    step: int | None = None
+    timestamp: int | None = None
+
+
+class MetricPoint(BaseModel):
+    step: int
+    value: float
+    timestamp: int | None = None
+
+
+class MetricHistory(BaseModel):
+    key: str
+    points: list[MetricPoint]
+
+
+class ArtifactEntry(BaseModel):
+    path: str
+    is_dir: bool
+    size: int | None = None
+
+
+class RunDetail(RunSummary):
+    artifact_uri: str | None = None
+    mlflow_run_url: str | None = Field(default=None, description="Deep link to this run in the MLflow UI")
+
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Logged params unflattened back into the nested config tree",
+    )
+    config_flat: dict[str, str] = Field(
+        default_factory=dict, description="The raw flattened params exactly as MLflow stores them"
+    )
+    config_unflatten_error: str | None = Field(
+        default=None,
+        description="Set when params could not be unflattened (colliding dotted keys); config falls back to empty",
+    )
+
+    tags: dict[str, str] = {}
+    metrics: list[MetricSummary] = []
+    artifacts: list[ArtifactEntry] = []
+    manifest: dict[str, Any] | None = Field(
+        default=None, description="Parsed manifest.json when the run logged one (ergodicio/tsadar#116)"
+    )
+
+
+class ErrorResponse(BaseModel):
+    detail: str

--- a/tsadar_browser/schemas.py
+++ b/tsadar_browser/schemas.py
@@ -53,6 +53,17 @@ class RunSummary(BaseModel):
         description="tsadar's own progress tag ('preprocessing', 'minimizing', ... 'completed'), when logged",
     )
     shot: str | None = Field(default=None, description="Shot number, from the data.shotnum param")
+    spectype: str | None = Field(
+        default=None,
+        description=(
+            "Spectrum type as logged ('temporal', 'imaging', 'angular', 'angular_full'). "
+            "A HINT, NOT GROUND TRUTH: log_mlflow runs before fitter.fit, and loadData "
+            "overwrites spectype from the data file during prepare, so a deck saying "
+            "'temporal' run against angular data logs 'temporal'. Confirm from artifact "
+            "shape (binary/fit_and_data.nc is angular; ele_/ion_fit_and_data.nc is 1D) "
+            "before rendering anything axis-dependent."
+        ),
+    )
     final_loss: float | None = None
     loss_key: str | None = Field(default=None, description="Which metric final_loss was read from")
     start_time: int | None = Field(default=None, description="Unix epoch milliseconds")

--- a/tsadar_browser/settings.py
+++ b/tsadar_browser/settings.py
@@ -1,0 +1,97 @@
+"""Configuration for the Thomson analysis browser backend.
+
+Everything is env-driven so the container needs no config file. The MLflow
+credential variables keep their canonical names (``MLFLOW_TRACKING_URI`` and
+friends) because the mlflow client reads them straight out of ``os.environ``;
+:meth:`Settings.apply_to_environment` pushes values loaded from a ``.env`` file
+back out so the client sees them too.
+"""
+
+import os
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+
+from typing import Annotated
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+DEFAULT_TRACKING_URI = "https://continuum.ergodic.io/experiments"
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore", case_sensitive=False)
+
+    mlflow_tracking_uri: str = DEFAULT_TRACKING_URI
+    mlflow_tracking_username: str | None = None
+    mlflow_tracking_password: str | None = None
+
+    cache_dir: Path = Field(default_factory=lambda: Path(tempfile.gettempdir()) / "tsadar-browser-cache")
+    cache_max_gb: float = 10.0
+
+    # The Vite dev server runs on a different origin than uvicorn; in the
+    # deployed image the SPA is served same-origin so this stays empty.
+    # NoDecode opts out of pydantic-settings' JSON parsing so the validator
+    # below can accept the comma-separated form a task definition would use.
+    cors_origins: Annotated[list[str], NoDecode] = ["http://localhost:5173", "http://127.0.0.1:5173"]
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def _split_origins(cls, value: object) -> object:
+        """Accept ``a,b`` as well as a real list, and treat empty as 'no CORS'."""
+        if isinstance(value, str):
+            return [origin.strip() for origin in value.split(",") if origin.strip()]
+        return value
+
+    # search_runs page size ceiling. MLflow itself caps at 50000, but the run
+    # browser table has no use for pages that large.
+    max_page_size: int = 200
+
+    # MLflow's own defaults are a 120s timeout with 7 retries and a backoff
+    # factor of 2, so one unreachable-server call can block for minutes. That is
+    # unusable behind a load balancer health check and unpleasant in a UI, so the
+    # browser bounds it hard: a failure should surface as 'degraded' quickly.
+    mlflow_http_timeout: int = 15
+    mlflow_http_max_retries: int = 2
+    mlflow_http_backoff_factor: int = 1
+
+    # How long a successful/failed reachability probe is trusted, so a burst of
+    # health checks does not turn into a burst of MLflow requests.
+    health_probe_ttl_s: float = 5.0
+
+    @property
+    def cache_max_bytes(self) -> int:
+        return int(self.cache_max_gb * 1024**3)
+
+    @property
+    def mlflow_ui_base(self) -> str:
+        """Base URL for deep links back into the MLflow UI."""
+        return self.mlflow_tracking_uri.rstrip("/")
+
+    def apply_to_environment(self) -> None:
+        """Export MLflow settings so the mlflow client picks them up.
+
+        The client reads all of these from ``os.environ`` directly, which is why
+        they are pushed back out here rather than passed as arguments.
+        """
+        os.environ["MLFLOW_TRACKING_URI"] = self.mlflow_tracking_uri
+        for name, value in (
+            ("MLFLOW_TRACKING_USERNAME", self.mlflow_tracking_username),
+            ("MLFLOW_TRACKING_PASSWORD", self.mlflow_tracking_password),
+        ):
+            if value:
+                os.environ[name] = value
+
+        # Only set if the operator has not overridden them explicitly.
+        for name, value in (
+            ("MLFLOW_HTTP_REQUEST_TIMEOUT", self.mlflow_http_timeout),
+            ("MLFLOW_HTTP_REQUEST_MAX_RETRIES", self.mlflow_http_max_retries),
+            ("MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR", self.mlflow_http_backoff_factor),
+        ):
+            os.environ.setdefault(name, str(value))
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()


### PR DESCRIPTION
Closes #29. First of seven PRs against the tracking issue #37, one per issue.

MLflow is treated as a read-only database — no new database, no writes anywhere in this diff. The OpenAPI schema at `/api/openapi.json` is the contract #31's generated TypeScript client will consume.

## Endpoints

| Endpoint | Notes |
| --- | --- |
| `GET /api/health` | Liveness, MLflow reachability, cache stats |
| `GET /api/experiments` | Active experiments |
| `GET /api/runs` | Filter by experiment/shot/status/stage/user, free-text on run name, sort, paginate |
| `GET /api/runs/{run_id}` | Config tree, tags, metric summaries, recursive artifact listing, `manifest.json` when present |
| `GET /api/runs/{run_id}/metrics/{key}` | Full metric history for loss curves |
| `GET /api/runs/{run_id}/artifacts/{path}` | Streaming passthrough with content type, so the frontend never touches S3 credentials |

Full documentation is in [`docs/browser.md`](docs/browser.md).

## Things I found in the code that changed the design

These are worth a look because several contradict assumptions in the issue text:

**There is no metric named `loss`.** tsadar logs `overall loss`, `min loss`, `epoch loss` and `batch loss` — names containing **spaces** (`tsadar/inverse/fitter.py`, `loops.py`). So `final_loss` picks the first present by preference order and reports which one it used in `loss_key`, ensuring the run table never silently compares two different quantities. Metric-history paths arrive URL-encoded (`/metrics/overall%20loss`). #32 will want to know this, since it currently specifies `metrics/loss`.

**MLflow lifecycle status and tsadar's progress tag are different things**, and both are useful, so both are exposed. `status` is `RUNNING`/`FINISHED`/`FAILED`/`KILLED`; `stage` is tsadar's own `status` **tag** (`preprocessing` → `minimizing` → `postprocessing` → `plotting` → `completed`). A `FAILED` run whose tag is stuck at `minimizing` is exactly the diagnostic a physicist wants. This also means **status filtering works today** without waiting on ergodicio/tsadar#115.

**Pagination is by cursor, not page number.** `GET /api/runs` takes `page_token` and returns `next_page_token`, deviating from the `page=` sketched in #29 — MLflow's `search_runs` paginates by opaque token, so offset paging would mean walking every preceding page on each request.

**MLflow's HTTP defaults would have broken the health check.** They are a 120s timeout with 7 retries and backoff factor 2, so one call to an unreachable server can block for *minutes* — behind an ALB, indistinguishable from a hung task. Bounded to 15s / 2 retries, and `/api/health` returns **200 `degraded`** rather than erroring, so the load balancer doesn't recycle a task that can still explain itself. Verified: an unreachable tracking server now yields `degraded` in ~2.2s instead of hanging. Reachability probes are cached for 5s so a polling ALB doesn't become a request storm.

## Safety details

- **Filter injection**: MLflow's filter grammar has no escape sequence for a quote inside a string literal, so values containing `'`, `"` or `\` are rejected with a 400 rather than interpolated into a query that would mean something else. Sort keys are allowlisted, not interpolated.
- **Path traversal**: artifact paths reject any `..` segment, and the resolved path is separately re-checked to fall inside the cache root. Absolute-looking paths are relativized rather than rejected — harmless once the leading slash is gone.
- **Error mapping** defers to MLflow's own `get_http_status_code()` rather than matching error-code strings, so `RESOURCE_DOES_NOT_EXIST` → 404 and `INVALID_PARAMETER_VALUE` → 400 (my first pass had the latter wrong). Upstream failures become 502.

## Caching

Keyed `run_id/path`, which is also the on-disk layout, so it's inspectable with `ls`. Terminal runs are immutable, so their artifacts cache indefinitely under a `CACHE_MAX_GB` cap with LRU eviction by mtime (bumped on hit — `atime` is unreliable on the `relatime` mounts containers get). `RUNNING` runs re-fetch every time since their artifacts may still be rewritten. Downloads stage in a scratch dir inside the cache root and move into place atomically, so an interrupted fetch never leaves a truncated entry; concurrent requests for the same cold artifact share one download.

## Config round-trip

`tsadar.utils.misc.log_mlflow` flattens the config with a dot reducer before logging, so `/api/runs/{run_id}` unflattens it back into `config`, re-parsing scalars as YAML so numbers, booleans and lists return as themselves (`"None"` special-cased — it isn't a YAML null token). Raw flat params stay available as `config_flat`. Runs with colliding dotted keys have an ill-defined tree, so `config` is left empty and `config_unflatten_error` explains why instead of the API guessing.

## Testing

85 tests, all passing, against a fake MLflow client — no credentials, no network, so they run in CI as-is.

```
$ python -m pytest tests/browser -q
85 passed
```

Also boot-tested under uvicorn against an unreachable tracking server to confirm the degraded-health and timeout behavior above.

A minimal `browser-tests.yaml` workflow runs them on PRs. It's deliberately thin — **#34 owns CI properly** (container build, `/api/health` smoke test, generated-client sync check) and should extend or absorb it. It exists now so the backend is guarded from the first merge rather than the last.

## Not in this PR

- No netCDF reading — that's #30. Worth flagging early: I checked `plotters.py` and the `binary/*.nc` datasets contain **only** `fit` and `data` variables, not the "data, fit, IRF and residuals" #30 assumes. Residual is derivable as `data - fit`, but IRF and noise components aren't in the netCDFs at all — they only exist inside the pre-rendered lineout PNGs. I'll serve residual as derived and report IRF as unavailable rather than inventing it.
- Nothing touching the Streamlit app or tesseract, both of which stay as they are.
- No job submission; #35 is deferred pending ergodicio/continuum-infra#133.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM8XjWjnJ1iKv19BS9c9Ab)_