### PR TITLE
Enforce the artifact cache cap on all fetch paths; stop leaking per-key locks

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -140,9 +140,21 @@ literal, so filter values containing `'`, `"` or `\` are rejected with a 400
 rather than being interpolated into a query that would mean something else.
 Sort keys are allowlisted for the same reason.
 
+In `q`, `%` and `_` remain live SQL `LIKE` wildcards rather than literals.
+MLflow's filter grammar has no `ESCAPE` clause, and the backslash an escape would
+need is already rejected as un-quotable, so this is documented behavior rather
+than half-escaped: `q=scan%01` matches "scan" followed by anything then "01".
+
 **Sorting** accepts `created`, `name`, `status`, `shot`, `loss` (prefix with `-`
 for descending). Duration is *not* sortable: it is computed from start/end
 timestamps and MLflow cannot order by it.
+
+`sort=loss` orders on the **`overall loss` metric specifically**. MLflow can only
+order by a named metric, so sorting cannot follow the same per-run fallback that
+`final_loss` uses: a run that logged only `min loss` sorts as though it had no
+loss, even though the table shows a value for it. `loss_key` is what makes that
+visible, so a client rendering a loss column should surface it rather than
+presenting the column as uniformly comparable.
 
 **`final_loss` reports which metric it came from.** tsadar logs several loss
 metrics whose names contain spaces — `overall loss`, `min loss`, `epoch loss`.
@@ -173,6 +185,21 @@ the cache root and are moved into place atomically, so an interrupted fetch neve
 leaves a truncated entry. Concurrent requests for the same cold artifact share
 one download. Eviction is least-recently-used by mtime (bumped on each hit, since
 `atime` is unreliable on the `relatime` mounts containers usually get).
+
+The size cap is enforced after **every** fetch, including non-cacheable ones —
+those still write into the cache root, so skipping eviction there would let the
+directory grow past `CACHE_MAX_GB` until some later cacheable fetch cleaned up.
+
+The artifact a fetch is about to return is exempt from that eviction pass. Once
+Starlette has the file open, unlinking it is harmless on POSIX (the descriptor
+keeps the data alive), but there is a window between the fetch returning and the
+response opening the file where deleting it would produce a spurious 404. One
+consequence worth knowing: a single artifact larger than the whole cap leaves the
+cache over its limit rather than evicting the file being served. That is logged at
+`WARNING` rather than silently tolerated.
+
+Per-key download locks are reference counted and dropped once no thread is
+waiting, so the lock table does not grow for the lifetime of the process.
 
 ## What this does not do
 

--- a/tests/browser/test_cache.py
+++ b/tests/browser/test_cache.py
@@ -1,7 +1,9 @@
 """Artifact cache: path safety, hits, and LRU eviction."""
 
 import os
+import threading
 import time
+from collections import Counter
 
 import pytest
 
@@ -114,6 +116,96 @@ def test_eviction_removes_least_recently_used_first(tmp_path):
     entries, total = cache.stats()
     assert entries == 1
     assert total <= 300
+
+
+def test_cap_is_enforced_on_the_non_cacheable_path(tmp_path):
+    """Non-cacheable fetches still write into the cache root, so they must evict.
+
+    Regression: eviction only ran for cacheable=True, so repeated reads of a
+    RUNNING run's artifacts grew the directory past CACHE_MAX_GB until some later
+    cacheable fetch happened to clean up.
+    """
+    cache = ArtifactCache(root=tmp_path / "cache", max_bytes=1000)
+
+    def write(name):
+        def downloader(scratch):
+            target = scratch / name
+            target.write_bytes(b"x" * 800)
+            return target
+
+        return cache.fetch("run-live", name, downloader, cacheable=False)
+
+    write("a.bin")
+    write("b.bin")
+    write("c.bin")
+
+    _, total = cache.stats()
+    assert total <= 1000
+
+
+def test_just_fetched_file_is_not_evicted(tmp_path):
+    """The file being returned must survive to be streamed."""
+    cache = ArtifactCache(root=tmp_path / "cache", max_bytes=100)
+
+    def downloader(scratch):
+        target = scratch / "big.bin"
+        target.write_bytes(b"x" * 5000)
+        return target
+
+    result = cache.fetch("run-1", "big.bin", downloader, cacheable=True)
+    assert result.exists(), "an artifact larger than the cap must still be served"
+    assert result.read_bytes() == b"x" * 5000
+
+
+def test_key_locks_do_not_accumulate(tmp_path):
+    """Regression: a lock per distinct artifact leaked for the process lifetime."""
+    cache = ArtifactCache(root=tmp_path / "cache", max_bytes=10**9)
+
+    def downloader(scratch):
+        target = scratch / "a"
+        target.write_bytes(b"y" * 10)
+        return target
+
+    for index in range(25):
+        cache.fetch("run-1", f"p{index}/a", downloader, cacheable=True)
+
+    assert cache._key_locks == {}
+    assert cache._key_waiters == Counter()
+
+
+def test_key_lock_is_released_when_the_download_fails(tmp_path):
+    cache = ArtifactCache(root=tmp_path / "cache", max_bytes=10**9)
+
+    with pytest.raises(FileNotFoundError):
+        cache.fetch("run-1", "a.bin", lambda scratch: scratch / "absent", cacheable=True)
+
+    assert cache._key_locks == {}
+
+
+def test_concurrent_fetches_of_one_key_download_once(tmp_path):
+    """The dedup the per-key lock exists for must survive reference counting."""
+    cache = ArtifactCache(root=tmp_path / "cache", max_bytes=10**9)
+    downloads = []
+    start = threading.Barrier(8)
+
+    def downloader(scratch):
+        downloads.append(1)
+        target = scratch / "a.bin"
+        target.write_bytes(b"payload")
+        return target
+
+    def worker():
+        start.wait()
+        cache.fetch("run-1", "a.bin", downloader, cacheable=True)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(downloads) == 1, "concurrent requests for a cold artifact should share one download"
+    assert cache._key_locks == {}
 
 
 def test_stats_on_missing_root(tmp_path):

--- a/tsadar_browser/cache.py
+++ b/tsadar_browser/cache.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import tempfile
 import threading
-from collections import defaultdict
+from collections import Counter
 from pathlib import Path
 from typing import Callable
 
@@ -57,7 +57,23 @@ class ArtifactCache:
         self.root = Path(root)
         self.max_bytes = max_bytes
         self._global_lock = threading.Lock()
-        self._key_locks: dict[str, threading.Lock] = defaultdict(threading.Lock)
+        # Per-key download locks, reference counted so the mapping does not grow
+        # for the lifetime of the process. A lock is dropped once no thread is
+        # waiting on it; the next request for that key makes a fresh one.
+        self._key_locks: dict[str, threading.Lock] = {}
+        self._key_waiters: Counter[str] = Counter()
+
+    def _claim_key_lock(self, key: str) -> threading.Lock:
+        with self._global_lock:
+            self._key_waiters[key] += 1
+            return self._key_locks.setdefault(key, threading.Lock())
+
+    def _release_key_lock(self, key: str) -> None:
+        with self._global_lock:
+            self._key_waiters[key] -= 1
+            if self._key_waiters[key] <= 0:
+                del self._key_waiters[key]
+                self._key_locks.pop(key, None)
 
     # -- layout ---------------------------------------------------------------
 
@@ -117,26 +133,32 @@ class ArtifactCache:
 
         # One download per key: concurrent requests for the same cold artifact
         # would otherwise each pull the whole file from S3.
-        with self._global_lock:
-            key_lock = self._key_locks[f"{run_id}/{artifact_path}"]
+        key = f"{run_id}/{artifact_path}"
+        key_lock = self._claim_key_lock(key)
+        try:
+            with key_lock:
+                if cacheable:
+                    hit = self.get(run_id, artifact_path)
+                    if hit is not None:
+                        return hit
 
-        with key_lock:
-            if cacheable:
-                hit = self.get(run_id, artifact_path)
-                if hit is not None:
-                    return hit
+                target.parent.mkdir(parents=True, exist_ok=True)
+                # Stage inside the cache root so the final move is same-filesystem
+                # and therefore atomic.
+                with tempfile.TemporaryDirectory(dir=self.root) as scratch:
+                    downloaded = Path(downloader(Path(scratch)))
+                    if not downloaded.is_file():
+                        raise FileNotFoundError(f"downloader did not produce a file for {artifact_path!r}")
+                    os.replace(downloaded, target)
+        finally:
+            self._release_key_lock(key)
 
-            target.parent.mkdir(parents=True, exist_ok=True)
-            # Stage inside the cache root so the final move is same-filesystem
-            # and therefore atomic.
-            with tempfile.TemporaryDirectory(dir=self.root) as scratch:
-                downloaded = Path(downloader(Path(scratch)))
-                if not downloaded.is_file():
-                    raise FileNotFoundError(f"downloader did not produce a file for {artifact_path!r}")
-                os.replace(downloaded, target)
-
-        if cacheable:
-            self.evict_if_needed()
+        # Enforce the cap on both paths. Non-cacheable fetches still write into
+        # the cache root, so skipping eviction here let the directory grow past
+        # CACHE_MAX_GB until the next cacheable fetch happened to clean up.
+        # `protect` keeps the file we are about to hand to the caller from being
+        # evicted out from under the response that is about to stream it.
+        self.evict_if_needed(protect=target)
         return target
 
     # -- eviction -------------------------------------------------------------
@@ -159,12 +181,19 @@ class ArtifactCache:
         entries = self._entries()
         return len(entries), sum(size for _, size, _ in entries)
 
-    def evict_if_needed(self) -> int:
+    def evict_if_needed(self, protect: Path | None = None) -> int:
         """Delete least-recently-used files until under the size cap.
 
-        Returns the number of bytes freed. Deleting a file that is currently
-        being streamed is safe on POSIX -- the open descriptor keeps it alive
-        until the response finishes.
+        Returns the number of bytes freed. ``protect`` is never evicted, which is
+        how a just-fetched artifact survives long enough to be streamed: once
+        Starlette has the file open, unlinking it is harmless on POSIX because
+        the descriptor keeps the data alive, but there is a window between
+        :meth:`fetch` returning and the response opening the file where deleting
+        it would produce a spurious 404.
+
+        A single artifact larger than the whole cap therefore leaves the cache
+        over its limit rather than evicting the file that is about to be served.
+        That is logged rather than silently tolerated.
         """
         with self._global_lock:
             entries = self._entries()
@@ -172,8 +201,11 @@ class ArtifactCache:
             if total <= self.max_bytes:
                 return 0
 
+            protected = protect.resolve() if protect is not None else None
             freed = 0
             for path, size, _ in sorted(entries, key=lambda item: item[2]):
+                if protected is not None and path.resolve() == protected:
+                    continue
                 try:
                     path.unlink()
                 except OSError:  # pragma: no cover - raced with another evictor
@@ -184,6 +216,13 @@ class ArtifactCache:
                     break
 
             logger.info("evicted %d bytes from artifact cache", freed)
+            if total > self.max_bytes:
+                logger.warning(
+                    "artifact cache still %d bytes over its %d byte cap after eviction; "
+                    "a single artifact may exceed CACHE_MAX_GB",
+                    total - self.max_bytes,
+                    self.max_bytes,
+                )
             return freed
 
     def clear(self) -> None:

--- a/tsadar_browser/gateway.py
+++ b/tsadar_browser/gateway.py
@@ -59,6 +59,13 @@ LOSS_KEYS = ("overall loss", "min loss", "epoch loss", "loss")
 
 #: Sort keys the API accepts, mapped to MLflow ``order_by`` expressions.
 #: Allowlisted rather than interpolated: these land in a query string.
+#:
+#: Note ``loss`` sorts specifically on ``overall loss`` -- MLflow can only order
+#: by a named metric, so it cannot follow the same per-run fallback that
+#: :data:`LOSS_KEYS` gives ``final_loss``. A run that logged only ``min loss``
+#: therefore sorts as though it had no loss at all, even though the table shows
+#: a value. ``loss_key`` in the response is what makes that visible, so clients
+#: displaying a loss column should surface it.
 SORTABLE = {
     "created": "attributes.start_time",
     "start_time": "attributes.start_time",
@@ -186,6 +193,10 @@ class MlflowGateway:
         if stage:
             clauses.append(f'tags."{STAGE_TAG}" = {_quote(stage)}')
         if q:
+            # `%` and `_` inside q stay live SQL LIKE wildcards. MLflow's filter
+            # grammar offers no ESCAPE clause and _quote already rejects the
+            # backslash an escape would need, so this is documented as the
+            # behavior rather than silently half-escaped.
             clauses.append(f"attributes.run_name LIKE {_quote(f'%{q}%')}")
 
         return " and ".join(clauses)

--- a/tsadar_browser/routes/runs.py
+++ b/tsadar_browser/routes/runs.py
@@ -50,10 +50,27 @@ def list_runs(
     ] = None,
     stage: Annotated[str | None, Query(description="tsadar progress tag, e.g. 'minimizing', 'completed'")] = None,
     user: Annotated[str | None, Query(description="Submitting user (mlflow.user tag)")] = None,
-    q: Annotated[str | None, Query(description="Free-text substring match on run name")] = None,
+    q: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Free-text substring match on run name. '%' and '_' act as SQL LIKE "
+                "wildcards (any-sequence and any-character) rather than literals; "
+                "MLflow's filter grammar has no ESCAPE clause to make them literal."
+            )
+        ),
+    ] = None,
     sort: Annotated[
         str | None,
-        Query(description="Sort key; prefix with '-' for descending. One of created, name, status, shot, loss."),
+        Query(
+            description=(
+                "Sort key; prefix with '-' for descending. One of created, name, status, shot, loss. "
+                "'loss' orders on the 'overall loss' metric specifically -- unlike final_loss it "
+                "cannot fall back to 'min loss'/'epoch loss', so runs lacking 'overall loss' sort "
+                "as null; check loss_key when displaying the value. Duration is not sortable: it is "
+                "computed from timestamps and MLflow cannot order by it."
+            )
+        ),
     ] = None,
     page_size: Annotated[int, Query(ge=1, description="Rows per page")] = 50,
     page_token: Annotated[


### PR DESCRIPTION
Follow-up to the review on #38. All five points are addressed — three were real defects, two were behavior that needed documenting rather than changing.

Kept separate from #30 so the netCDF slicing diff stays about netCDF slicing. Small and self-contained; the tests are the interesting part.

## The three defects

**1. The cap wasn't enforced on the non-cacheable path.** Confirmed your reproduction exactly: 3 fetches × 5 KB against a 1000-byte cap gave `(3, 15000)`. `cacheable=False` still `os.replace`s into the cache root, so eviction has to run there too. Now it does.

**2. `_key_locks` leaked.** Also confirmed — 50 locks after 50 distinct artifacts. Replaced the `defaultdict` with reference-counted locks, dropped once no thread is waiting; the next request for that key makes a fresh one. The lock table returns to empty.

The risk in that change is quietly destroying the dedup the locks exist for, so there's a test that races 8 threads on one cold artifact through a `Barrier` and asserts exactly one download — plus one asserting the lock is released when the download raises.

**3. The eviction/`FileResponse` race is closed, not just documented.** You were right that the docstring was more reassuring than the code. Rather than soften the wording, the artifact a fetch is about to return is now exempt from that eviction pass, which removes the window entirely. The docstring no longer implies the open-descriptor argument covers the period *before* the response opens the file.

That has a consequence worth stating plainly: a single artifact larger than the whole cap now leaves the cache over its limit rather than evicting the file it's about to serve. That's the right trade — serving the request beats honoring an advisory cap — and it logs at `WARNING` instead of passing silently:

```
artifact cache still 4000 bytes over its 1000 byte cap after eviction;
a single artifact may exceed CACHE_MAX_GB
```

## The two documentation items

**4. `q` wildcards.** `%` and `_` stay live `LIKE` wildcards. I looked for a proper fix and there isn't a clean one: MLflow's filter grammar has no `ESCAPE` clause, and the backslash an escape would need is already rejected by `_quote` as un-quotable. Half-escaping would be worse than either extreme, so it's now stated in the OpenAPI description and the docs.

**5. `sort=loss` vs `final_loss`.** Agreed this isn't a bug — MLflow can only order by a named metric, so sorting structurally cannot follow the per-run fallback. Documented on both `SORTABLE` and the `sort` query param, including the specific failure mode (a run with only `min loss` sorts as null while displaying a value) and the pointer that clients rendering a loss column should surface `loss_key`. I've left the same note on #31 so the run table is built with it in mind.

## Testing

93 passing (5 new, covering: cap enforced on the non-cacheable path, oversized artifact still served, lock table returns to empty, lock released on failure, and concurrent dedup preserved).

```
$ python -m pytest tests/browser -q
93 passed
```

Thanks for the independent verification in the review — reproducing findings 1 and 2 as concrete numbers made them quick to confirm and fix rather than reason about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM8XjWjnJ1iKv19BS9c9Ab)_