### PR TITLE
Browser backend: netCDF slicing endpoints for interactive plots

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -103,6 +103,10 @@ defaults above.
 | `GET /api/runs/{run_id}` | Config tree, tags, metric summaries, artifact listing, manifest |
 | `GET /api/runs/{run_id}/metrics/{key}` | Full metric history for loss curves |
 | `GET /api/runs/{run_id}/artifacts/{path}` | Streaming passthrough with content type |
+| `GET /api/runs/{run_id}/datasets` | What interactive views this run supports, and why not when it doesn't |
+| `GET /api/runs/{run_id}/spectrogram` | 2D array, block-averaged to a pixel budget |
+| `GET /api/runs/{run_id}/lineout` | Measured vs fitted spectrum at one lineout |
+| `GET /api/runs/{run_id}/profiles` | Fitted parameters vs lineout, with sigmas where available |
 
 ### Notes on the contract
 
@@ -201,11 +205,102 @@ cache over its limit rather than evicting the file being served. That is logged 
 Per-key download locks are reference counted and dropped once no thread is
 waiting, so the lock table does not grow for the lifetime of the process.
 
+## Interactive plots from the netCDF datasets
+
+These endpoints ([#30]) are what make the browser better than a PNG gallery: they
+render from the arrays the fit actually produced.
+
+### Probe first
+
+`GET /api/runs/{id}/datasets` answers for **every** run — angular, pre-contract,
+or fully supported — rather than erroring, so the run detail view ([#32]) can pick
+a layout in one call:
+
+```json
+{
+  "kind": "one_d",
+  "supported": true,
+  "spectra": [{"which": "ele", "x_label": "Time (ps)", "lineout_count": 60,
+               "wavelength_count": 1024, "fields": ["data", "fit", "residual"]}],
+  "profiles_available": true,
+  "sigmas_available": false,
+  "unavailable_fields": {"irf": "..."}
+}
+```
+
+When a run can't be served, `supported` is false and `reason` is a code, not
+prose: `angular_not_supported`, `dataset_missing`, `dataset_unreadable`,
+`unexpected_schema`, `field_unavailable`, `index_out_of_range`. The distinction
+matters — showing "no data found" for an angular run reads as a bug when the
+truth is that the view is deliberately out of scope. The data endpoints use the
+same codes in their error bodies, with **409** for recognized-but-unsupported
+(angular) and **404** for genuinely absent.
+
+### What the datasets actually contain
+
+Less than [#30] assumed, so two things are worth stating plainly:
+
+- **Residual is derived**, as `data - fit`. It isn't stored.
+- **IRF and noise components are not in the netCDFs at all.** `plotters.py`
+  writes `{"fit": ..., "data": ...}` and nothing else; the components exist only
+  baked into the pre-rendered `lineouts/`, `best/` and `worst/` PNGs. They are
+  reported through `unavailable_fields` / `components_unavailable` rather than
+  invented. Making them genuinely available is a `plotters.py` change and
+  probably belongs with [ergodicio/tsadar#116].
+
+`sigmas.nc` lives at the artifact **root**, not under `binary/` — `calc_sigmas`
+is off by default, so absence is normal rather than an error. In
+`learned_parameters.csv`, `to_csv` writes the DataFrame index as a leading
+unnamed column, and the lineout axis column is identified by its parenthesized
+units (`Time (ps)`) since parameter columns are `<param>_<species>`.
+
+### Downsampling
+
+`max_px` is a pixel budget; the array is **block-averaged** (not decimated) down
+to it, so a narrow spectral feature is attenuated rather than skipped entirely.
+
+**Wavelength is reduced first and the lineout axis is spared wherever possible.**
+Each lineout is a separate fit with its own parameters, and it's the axis the
+scrubber in [#32] steps through, so trading lineouts for bytes costs far more than
+spectral resolution does. At a realistic 60 × 1024 against a 2000-pixel budget
+that means 60 × 32 — every lineout intact — rather than 30 × 34. The response
+reports `downsample_factors`, `downsample_method`, `full_shape` and
+`returned_shape` so the UI can say what it's showing.
+
+`values` is shaped `(len(y), len(x))` — row-major by wavelength — so it drops
+straight into a Plotly heatmap `z`, which is indexed `[y][x]`.
+
+The default `max_px` is **20,000**, deliberately below a realistic
+full-resolution spectrogram (60 × 1024 = 61,440), because [#30] asks that full
+resolution never be shipped by default. A heatmap panel is a few hundred pixels
+tall, so 1024 spectral points are already oversampled for display; clients that
+genuinely want everything can raise `max_px`.
+
+### Non-finite values and precision
+
+JSON has no NaN or Infinity, and Python's `json.dumps` emits a bare `NaN` that
+makes browser `JSON.parse` throw. Gaps in a fit are therefore serialized as
+`null` throughout these endpoints.
+
+Values are trimmed to **6 significant digits**. Full float repr roughly doubles
+the payload (a 60 × 256 spectrogram goes from ~290 KB to ~130 KB) for precision no
+plot can show. This is display data; anything needing the exact stored values
+should fetch the `.nc` through the artifact passthrough instead.
+
+One consequence: `residual` is differenced at full precision and *then* rounded,
+so it is not bit-identical to `data - fit` computed from the rounded arrays. The
+gap is the double-rounding floor — around 9e-6 absolute at these magnitudes.
+
 ## What this does not do
 
-No netCDF reading — that is [#30]. No writes of any kind, so no job submission;
-the Streamlit app's submit path targets retired infrastructure and is not
-resurrected here ([#35]).
+No writes of any kind, so no job submission; the Streamlit app's submit path
+targets retired infrastructure and is not resurrected here ([#35]).
+
+Angular Thomson interactive views are out of scope by design (see Scope above) —
+not unimplemented, but deliberately refused.
+
+[#32]: https://github.com/ergodicio/tsadar-app/issues/32
+[ergodicio/tsadar#116]: https://github.com/ergodicio/tsadar/issues/116
 
 [#29]: https://github.com/ergodicio/tsadar-app/issues/29
 [#30]: https://github.com/ergodicio/tsadar-app/issues/30

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -232,9 +232,18 @@ When a run can't be served, `supported` is false and `reason` is a code, not
 prose: `angular_not_supported`, `dataset_missing`, `dataset_unreadable`,
 `unexpected_schema`, `field_unavailable`, `index_out_of_range`. The distinction
 matters — showing "no data found" for an angular run reads as a bug when the
-truth is that the view is deliberately out of scope. The data endpoints use the
-same codes in their error bodies, with **409** for recognized-but-unsupported
-(angular) and **404** for genuinely absent.
+truth is that the view is deliberately out of scope.
+
+The data endpoints carry the same codes in their **error** bodies, with **409**
+for recognized-but-unsupported (angular) and **404** for genuinely absent. Note
+the shape: FastAPI wraps anything an `HTTPException` carries under `detail`, so
+the reason is one level down and the declared schema mirrors that nesting.
+
+```json
+{ "detail": { "reason": "angular_not_supported", "detail": "This is an angularly-resolved run. …" } }
+```
+
+Read it as `err.detail.reason`, not `err.reason`.
 
 ### What the datasets actually contain
 
@@ -251,8 +260,20 @@ Less than [#30] assumed, so two things are worth stating plainly:
 `sigmas.nc` lives at the artifact **root**, not under `binary/` — `calc_sigmas`
 is off by default, so absence is normal rather than an error. In
 `learned_parameters.csv`, `to_csv` writes the DataFrame index as a leading
-unnamed column, and the lineout axis column is identified by its parenthesized
-units (`Time (ps)`) since parameter columns are `<param>_<species>`.
+unnamed column, and the lineout axis column is matched **by name** against the
+dataset's own axis label. The "first column with parenthesized units" heuristic
+is only a fallback: it is positional, and safe today purely because
+`get_final_params` inserts the axis ahead of the parameters, so a fitted
+parameter that ever acquired a unit in its name would otherwise be mistaken for
+the axis. Among parenthesized fallback candidates a monotonic one wins, since a
+lineout axis always is and a parameter generally is not.
+
+Classification lists only `binary/` rather than walking the whole artifact tree.
+A real run has `binary/`, `csv/`, `plots/`, `lineouts/`, `best/` and `worst/`, and
+each directory is an MLflow round trip; the lineout scrubber steps
+interactively, so a full walk would be paid before every step. `/datasets` still
+takes the full listing, because it reports on profiles and sigmas too — but it is
+called once per page load rather than once per interaction.
 
 ### Downsampling
 

--- a/requirements-browser.txt
+++ b/requirements-browser.txt
@@ -12,3 +12,12 @@ mlflow
 boto3
 flatten_dict
 PyYAML
+
+# Reading the binary/*.nc analysis datasets for the interactive plots.
+# h5netcdf + h5py rather than netCDF4: pure-wheel install with no libnetcdf
+# system dependency to carry into the container.
+xarray
+h5netcdf
+h5py
+numpy
+pandas

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -211,3 +211,90 @@ def client(gateway) -> TestClient:
 @pytest.fixture
 def manifest_bytes() -> bytes:
     return json.dumps({"schema_version": 1, "datasets": ["binary/ele_fit_and_data.nc"]}).encode()
+
+
+# -- dataset fixtures (issue #30) ---------------------------------------------
+
+
+def install_artifacts(fake_client: FakeMlflowClient, run_id: str, files: dict[str, bytes]) -> None:
+    """Register artifact bytes and the directory listing that exposes them.
+
+    The gateway lists artifacts to classify a run before reading anything, so a
+    test that only registers bytes would look like a run with no artifacts.
+    """
+    fake_client.artifact_files.setdefault(run_id, {}).update(files)
+
+    listing: dict[str, list] = {}
+    for path in files:
+        parent, _, _ = path.rpartition("/")
+        listing.setdefault(parent, []).append(file_info(path, file_size=len(files[path])))
+        if parent and not any(entry.path == parent for entry in listing.get("", [])):
+            listing.setdefault("", []).append(file_info(parent, is_dir=True))
+    fake_client.artifacts[run_id] = listing
+
+
+@pytest.fixture
+def dataset_service(gateway):
+    from tsadar_browser.datasets import DatasetService
+
+    return DatasetService(gateway=gateway)
+
+
+@pytest.fixture
+def dataset_client(gateway, dataset_service) -> TestClient:
+    from tsadar_browser.deps import get_dataset_service
+
+    app = create_app()
+    app.dependency_overrides[get_gateway] = lambda: gateway
+    app.dependency_overrides[get_dataset_service] = lambda: dataset_service
+    return TestClient(app)
+
+
+@pytest.fixture
+def one_d_run(fake_client, tmp_path) -> str:
+    """A temporal run with ele + ion spectra, learned parameters and sigmas."""
+    from .fixtures import learned_parameters_csv, sigmas_netcdf, write_spectrum
+
+    run_id = "run-abc"
+    install_artifacts(
+        fake_client,
+        run_id,
+        {
+            "binary/ele_fit_and_data.nc": write_spectrum(tmp_path / "ele", "ele_fit_and_data.nc"),
+            "binary/ion_fit_and_data.nc": write_spectrum(tmp_path / "ion", "ion_fit_and_data.nc"),
+            "csv/learned_parameters.csv": learned_parameters_csv(),
+            "sigmas.nc": sigmas_netcdf(tmp_path / "sig"),
+            "plots/fit_and_data.png": b"\x89PNG\r\n\x1a\n",
+        },
+    )
+    return run_id
+
+
+@pytest.fixture
+def angular_run(fake_client, tmp_path) -> str:
+    """An angular run: same variables and dimensionality, angular x axis."""
+    from .fixtures import ANGULAR_AXIS, learned_parameters_csv, write_spectrum
+
+    run_id = "run-angular"
+    fake_client.runs[run_id] = make_run(run_id=run_id, params={**SAMPLE_PARAMS, "other.extraoptions.spectype": "angular_full"})
+    install_artifacts(
+        fake_client,
+        run_id,
+        {
+            "binary/fit_and_data.nc": write_spectrum(
+                tmp_path / "ang", "fit_and_data.nc", x_label=ANGULAR_AXIS
+            ),
+            "csv/learned_parameters.csv": learned_parameters_csv(include_axis=False),
+            "plots/fit_and_data.png": b"\x89PNG\r\n\x1a\n",
+        },
+    )
+    return run_id
+
+
+@pytest.fixture
+def bare_run(fake_client) -> str:
+    """A pre-contract run: PNGs only, no datasets."""
+    run_id = "run-old"
+    fake_client.runs[run_id] = make_run(run_id=run_id)
+    install_artifacts(fake_client, run_id, {"plots/fit_and_data.png": b"\x89PNG\r\n\x1a\n"})
+    return run_id

--- a/tests/browser/fixtures.py
+++ b/tests/browser/fixtures.py
@@ -1,0 +1,103 @@
+"""Builders for realistic tsadar analysis artifacts.
+
+These mirror what ``tsadar/utils/plotting/plotters.py`` actually writes, because
+the whole point of #30 is reading those files. In particular:
+
+- ``fit`` and ``data`` are the ONLY variables; residual is derived and IRF is
+  absent (``plotters.py`` lines 430, 477, 506).
+- dims are ``(<x_label>, "Wavelength")`` with a dynamic x name.
+- angular runs write ``binary/fit_and_data.nc`` with an angular x axis, and are
+  otherwise indistinguishable in shape from a 1D dataset.
+- ``learned_parameters.csv`` gets an unnamed index column from ``to_csv``, then
+  ``lineout pixel``, then the axis column, then the parameters.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+TEMPORAL_AXIS = "Time (ps)"
+SPATIAL_AXIS = r"Radius (\mum)"
+ANGULAR_AXIS = "Scattering angle (degrees)"
+WAVELENGTH = "Wavelength"
+
+
+def spectrum_dataset(
+    n_lineouts: int = 6,
+    n_wavelength: int = 32,
+    x_label: str = TEMPORAL_AXIS,
+    with_nan: bool = False,
+) -> xr.Dataset:
+    """A fit/data dataset shaped exactly like plotters.plot_ts_data writes."""
+    x = np.linspace(-100.0, 100.0, n_lineouts)
+    wavelength = np.linspace(520.0, 540.0, n_wavelength)
+    coords = (x_label, x), (WAVELENGTH, wavelength)
+
+    rng = np.random.default_rng(1234)
+    data = rng.random((n_lineouts, n_wavelength)) + 1.0
+    fit = data * 0.9
+
+    if with_nan:
+        # A real fit can leave gaps; these must serialize as null, not NaN.
+        data[0, 0] = np.nan
+        fit[1, 2] = np.inf
+
+    return xr.Dataset(
+        {
+            "fit": xr.DataArray(fit, coords=coords),
+            "data": xr.DataArray(data, coords=coords),
+        }
+    )
+
+
+def write_spectrum(directory: Path, name: str, **kwargs) -> bytes:
+    """Serialize a spectrum dataset to netCDF bytes."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    spectrum_dataset(**kwargs).to_netcdf(path)
+    return path.read_bytes()
+
+
+def learned_parameters_csv(
+    n_lineouts: int = 6,
+    x_label: str = TEMPORAL_AXIS,
+    include_axis: bool = True,
+) -> bytes:
+    """learned_parameters.csv as get_final_params writes it.
+
+    ``include_axis=False`` reproduces the angular case, where the
+    ``spectype != "angular_full"`` branch skips both inserts so there is no
+    lineout axis to plot profiles against.
+    """
+    frame = pd.DataFrame(
+        {
+            "Te_electron": np.linspace(0.4, 0.9, n_lineouts),
+            "ne_electron": np.linspace(0.1, 0.3, n_lineouts),
+            "amp1_general": np.linspace(1.0, 1.4, n_lineouts),
+        }
+    )
+    if include_axis:
+        frame.insert(0, x_label, np.linspace(-100.0, 100.0, n_lineouts))
+        frame.insert(0, "lineout pixel", np.arange(800, 800 + n_lineouts))
+
+    return frame.to_csv(index=True).encode()
+
+
+def sigmas_netcdf(directory: Path, n_lineouts: int = 6, x_label: str = TEMPORAL_AXIS) -> bytes:
+    """sigmas.nc as save_sigmas_params writes it -- at the artifact ROOT.
+
+    Variables are named ``<param>_<species>``, matching the CSV columns.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    coords = ((x_label, np.linspace(-100.0, 100.0, n_lineouts)),)
+    dataset = xr.Dataset(
+        {
+            "Te_electron": xr.DataArray(np.full(n_lineouts, 0.05), coords=coords),
+            "ne_electron": xr.DataArray(np.full(n_lineouts, 0.01), coords=coords),
+        }
+    )
+    path = directory / "sigmas.nc"
+    dataset.to_netcdf(path)
+    return path.read_bytes()

--- a/tests/browser/test_api.py
+++ b/tests/browser/test_api.py
@@ -208,16 +208,21 @@ class TestArtifactPassthrough:
 
 
 class TestOpenApi:
-    def test_schema_is_served_and_covers_every_endpoint(self, client):
-        """The frontend client is generated from this; #29 requires it stay honest."""
+    def test_schema_is_served_and_covers_the_read_layer(self, client):
+        """The frontend client is generated from this; #29 requires it stay honest.
+
+        A subset assertion rather than equality: later issues legitimately add
+        endpoints, and this test is about the read layer staying present, not
+        about the API never growing.
+        """
         response = client.get("/api/openapi.json")
         assert response.status_code == 200
         paths = response.json()["paths"]
-        assert set(paths) == {
+        assert {
             "/api/health",
             "/api/experiments",
             "/api/runs",
             "/api/runs/{run_id}",
             "/api/runs/{run_id}/metrics/{key}",
             "/api/runs/{run_id}/artifacts/{artifact_path}",
-        }
+        } <= set(paths)

--- a/tests/browser/test_datasets.py
+++ b/tests/browser/test_datasets.py
@@ -419,3 +419,109 @@ class TestWireFormat:
         assert result[0] == 0.0
         assert result[1] == pytest.approx(-1234.57)
         assert result[2] == pytest.approx(1e-30)
+
+
+class TestReviewRegressions:
+    """Cases from the review on #40."""
+
+    def test_declared_error_schema_matches_the_wire_body(self, dataset_client, angular_run):
+        """The generated client reads the schema, so a flat declaration lies.
+
+        FastAPI nests whatever an HTTPException carries under `detail`, so a
+        consumer trusting a flat schema would read err.reason and get undefined
+        on exactly the angular-vs-missing distinction these endpoints exist for.
+        """
+        response = dataset_client.get(f"/api/runs/{angular_run}/spectrogram")
+        assert response.status_code == 409
+        body = response.json()
+
+        schema = dataset_client.get("/api/openapi.json").json()
+        ref = schema["paths"]["/api/runs/{run_id}/spectrogram"]["get"]["responses"]["409"]["content"][
+            "application/json"
+        ]["schema"]["$ref"]
+        declared = schema["components"]["schemas"][ref.rsplit("/", 1)[-1]]
+
+        # Declared shape must be the envelope, not its contents.
+        assert list(declared["properties"]) == ["detail"]
+        inner_ref = declared["properties"]["detail"]["$ref"].rsplit("/", 1)[-1]
+        inner = schema["components"]["schemas"][inner_ref]
+        assert set(inner["properties"]) == {"reason", "detail"}
+
+        # And the wire body must actually match it.
+        assert set(body) == {"detail"}
+        assert set(body["detail"]) == {"reason", "detail"}
+        assert body["detail"]["reason"] == "angular_not_supported"
+
+    def test_serving_paths_list_only_the_binary_directory(self, fake_client, dataset_client, tmp_path):
+        """Classification must not walk the whole artifact tree per request.
+
+        A real run has binary/, csv/, plots/, lineouts/, best/ and worst/, and the
+        lineout scrubber steps interactively -- paying a round trip per directory
+        on every step before reading any data.
+        """
+        from .fixtures import learned_parameters_csv
+
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {
+                "binary/ele_fit_and_data.nc": write_spectrum(tmp_path / "e", "ele_fit_and_data.nc"),
+                "csv/learned_parameters.csv": learned_parameters_csv(),
+                "plots/a.png": b"x",
+                "lineouts/a.png": b"x",
+                "best/a.png": b"x",
+                "worst/a.png": b"x",
+            },
+        )
+
+        original = fake_client.list_artifacts
+        listed: list[str] = []
+
+        def counting(run_id, path=""):
+            listed.append(path)
+            return original(run_id, path)
+
+        fake_client.list_artifacts = counting
+
+        for endpoint in ("spectrogram", "lineout?index=0", "lineout?index=1"):
+            listed.clear()
+            assert dataset_client.get(f"/api/runs/run-abc/{endpoint}").status_code == 200
+            assert listed == ["binary"], f"{endpoint} walked {listed} instead of just binary/"
+
+    def test_describe_still_reports_profiles_and_sigmas(self, dataset_client, one_d_run):
+        """The narrower listing must not cost /datasets its fuller answer."""
+        body = dataset_client.get(f"/api/runs/{one_d_run}/datasets").json()
+        assert body["profiles_available"] is True
+        assert body["sigmas_available"] is True
+
+    def test_axis_column_is_matched_by_name_not_position(self, dataset_service):
+        """A parameter carrying a unit must not be mistaken for the lineout axis."""
+        import pandas as pd
+
+        frame = pd.DataFrame(
+            {
+                # Deliberately ahead of the real axis, which is what the
+                # positional heuristic alone would fall for.
+                "Te_electron (keV)": np.linspace(5.0, 1.0, 6),
+                TEMPORAL_AXIS: np.linspace(-100.0, 100.0, 6),
+                "ne_electron": np.linspace(0.1, 0.3, 6),
+            }
+        )
+        assert dataset_service._profile_axis_column(frame, TEMPORAL_AXIS) == TEMPORAL_AXIS
+
+    def test_axis_column_falls_back_to_a_monotonic_candidate(self, dataset_service):
+        """With no hint, prefer monotonicity: a lineout axis always is."""
+        import pandas as pd
+
+        frame = pd.DataFrame(
+            {
+                "Te_electron (keV)": np.array([5.0, 1.0, 4.0, 2.0, 3.0, 0.5]),
+                TEMPORAL_AXIS: np.linspace(-100.0, 100.0, 6),
+            }
+        )
+        assert dataset_service._profile_axis_column(frame, None) == TEMPORAL_AXIS
+
+    def test_profiles_uses_the_dataset_axis_name(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/profiles").json()
+        assert body["x_label"] == TEMPORAL_AXIS
+        assert TEMPORAL_AXIS not in {series["name"] for series in body["series"]}

--- a/tests/browser/test_datasets.py
+++ b/tests/browser/test_datasets.py
@@ -1,0 +1,421 @@
+"""Dataset slicing endpoints (issue #30).
+
+The tests that matter most here are the ones asserting angular runs are refused
+distinguishably, and that a 1D dataset is never substituted for an angular one --
+the two files have identical variables and dimensionality, so nothing but an
+explicit check separates them.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from tsadar_browser.datasets import DatasetUnavailable
+from tsadar_browser.schemas import DatasetKind, UnavailableReason
+
+from .conftest import install_artifacts, make_run
+from .fixtures import ANGULAR_AXIS, SPATIAL_AXIS, TEMPORAL_AXIS, write_spectrum
+
+
+class TestAvailability:
+    def test_one_d_run_is_supported(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/datasets").json()
+        assert body["kind"] == "one_d"
+        assert body["supported"] is True
+        assert body["reason"] is None
+        assert {s["which"] for s in body["spectra"]} == {"ele", "ion"}
+        assert body["profiles_available"] is True
+        assert body["sigmas_available"] is True
+
+    def test_spectrum_info_reports_shape_and_axis(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/datasets").json()
+        ele = next(s for s in body["spectra"] if s["which"] == "ele")
+        assert ele["x_label"] == TEMPORAL_AXIS
+        assert ele["y_label"] == "Wavelength"
+        assert (ele["lineout_count"], ele["wavelength_count"]) == (6, 32)
+        assert ele["fields"] == ["data", "fit", "residual"]
+
+    def test_irf_is_reported_unavailable_not_omitted(self, dataset_client, one_d_run):
+        """IRF genuinely isn't in the netCDFs; say so rather than staying silent."""
+        body = dataset_client.get(f"/api/runs/{one_d_run}/datasets").json()
+        assert "irf" in body["unavailable_fields"]
+        assert "not written to the netCDF" in body["unavailable_fields"]["irf"]
+
+    def test_angular_run_is_unsupported_with_a_reason(self, dataset_client, angular_run):
+        """Must answer 200 with a reason, so #32 can pick the gallery layout."""
+        response = dataset_client.get(f"/api/runs/{angular_run}/datasets")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["kind"] == "angular"
+        assert body["supported"] is False
+        assert body["reason"] == "angular_not_supported"
+        assert "angularly-resolved" in body["message"]
+        assert body["spectra"] == []
+
+    def test_pre_contract_run_is_unsupported_but_not_an_error(self, dataset_client, bare_run):
+        body = dataset_client.get(f"/api/runs/{bare_run}/datasets").json()
+        assert body["kind"] == "unknown"
+        assert body["supported"] is False
+        assert body["reason"] == "dataset_missing"
+
+    def test_run_with_only_ele_reports_only_ele(self, fake_client, dataset_client, tmp_path):
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {"binary/ele_fit_and_data.nc": write_spectrum(tmp_path / "e", "ele_fit_and_data.nc")},
+        )
+        body = dataset_client.get("/api/runs/run-abc/datasets").json()
+        assert [s["which"] for s in body["spectra"]] == ["ele"]
+        assert body["profiles_available"] is False
+
+
+class TestClassification:
+    def test_angular_dataset_is_never_used_as_a_fallback(self, dataset_service, angular_run):
+        """The trap: fit_and_data.nc has the same vars and rank as ele_fit_and_data.nc.
+
+        A "try the other file if ele/ion are absent" fallback would serve
+        angle-vs-wavelength data to a UI labelling its x-axis as time.
+        """
+        with pytest.raises(DatasetUnavailable) as caught:
+            dataset_service.spectrogram(angular_run, which="ele", field="data", max_px=None)
+        assert caught.value.reason is UnavailableReason.angular_not_supported
+        assert caught.value.status_code == 409
+
+    def test_classification_uses_artifacts_not_the_spectype_param(
+        self, fake_client, dataset_service, tmp_path
+    ):
+        """spectype is logged before the fit runs, so it can lie; artifacts can't."""
+        fake_client.runs["run-liar"] = make_run(
+            run_id="run-liar", params={"other.extraoptions.spectype": "angular_full"}
+        )
+        install_artifacts(
+            fake_client,
+            "run-liar",
+            {"binary/ele_fit_and_data.nc": write_spectrum(tmp_path / "l", "ele_fit_and_data.nc")},
+        )
+        kind, present = dataset_service.classify("run-liar")
+        assert kind is DatasetKind.one_d, "artifact shape should win over a stale param"
+        assert present == ["ele"]
+
+    def test_angular_axis_inside_a_1d_named_file_is_still_refused(
+        self, fake_client, dataset_service, tmp_path
+    ):
+        """Defense in depth: the axis name is checked even past the shape check."""
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {
+                "binary/ele_fit_and_data.nc": write_spectrum(
+                    tmp_path / "sneaky", "ele_fit_and_data.nc", x_label=ANGULAR_AXIS
+                )
+            },
+        )
+        with pytest.raises(DatasetUnavailable) as caught:
+            dataset_service.spectrogram("run-abc", which="ele", field="data", max_px=None)
+        assert caught.value.reason is UnavailableReason.angular_not_supported
+
+    def test_spatial_axis_is_supported(self, fake_client, dataset_service, tmp_path):
+        """Imaging runs are in scope; only angular is out."""
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {
+                "binary/ele_fit_and_data.nc": write_spectrum(
+                    tmp_path / "sp", "ele_fit_and_data.nc", x_label=SPATIAL_AXIS
+                )
+            },
+        )
+        result = dataset_service.spectrogram("run-abc", which="ele", field="data", max_px=None)
+        assert result.x_label == SPATIAL_AXIS
+
+
+class TestSpectrogram:
+    def test_returns_plotly_ready_orientation(self, dataset_client, one_d_run):
+        """values must be [y][x] so it drops straight into a heatmap z."""
+        body = dataset_client.get(f"/api/runs/{one_d_run}/spectrogram?which=ele&field=data").json()
+        assert len(body["y"]) == 32
+        assert len(body["x"]) == 6
+        assert len(body["values"]) == len(body["y"])
+        assert len(body["values"][0]) == len(body["x"])
+
+    def test_full_resolution_when_under_budget(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/spectrogram?max_px=100000").json()
+        assert body["downsample_method"] == "none"
+        assert body["downsample_factors"] == {"x": 1, "wavelength": 1}
+        assert body["returned_shape"] == body["full_shape"] == [6, 32]
+
+    def test_downsamples_wavelength_and_spares_lineouts(self, dataset_client, one_d_run):
+        """Each lineout is a separate fit and the scrubber axis, so it is preserved."""
+        body = dataset_client.get(f"/api/runs/{one_d_run}/spectrogram?max_px=48").json()
+        assert body["returned_shape"][0] == 6, "lineout axis should be spared"
+        assert body["downsample_factors"]["x"] == 1
+        assert body["downsample_factors"]["wavelength"] > 1
+        assert body["returned_shape"][0] * body["returned_shape"][1] <= 48
+        assert body["downsample_method"] == "mean"
+
+    def test_coarsens_lineouts_only_when_wavelength_is_not_enough(self, dataset_service, one_d_run):
+        result = dataset_service.spectrogram(one_d_run, which="ele", field="data", max_px=3)
+        assert result.downsample_factors["x"] > 1
+        assert result.returned_shape[0] * result.returned_shape[1] <= 6
+
+    @pytest.mark.parametrize(
+        ("n_lineouts", "n_wavelength", "budget"),
+        [(60, 1024, 20_000), (60, 1024, 2_000), (300, 1024, 5_000)],
+    )
+    def test_realistic_detector_shapes_keep_every_lineout(
+        self, dataset_service, n_lineouts, n_wavelength, budget
+    ):
+        """Wavelength is exhausted before any lineout is given up.
+
+        Integer division can leave the first factor estimate just over budget
+        (60x1024 to 2000 lands on 60x34 = 2040); tightening wavelength one more
+        step gets under it without dropping fits.
+        """
+        array = xr.DataArray(
+            np.zeros((n_lineouts, n_wavelength)),
+            coords=(
+                (TEMPORAL_AXIS, np.arange(n_lineouts, dtype=float)),
+                ("Wavelength", np.arange(n_wavelength, dtype=float)),
+            ),
+        )
+        reduced, (x_factor, _) = dataset_service._downsample(
+            array, TEMPORAL_AXIS, "Wavelength", budget
+        )
+        assert x_factor == 1, "no lineout should be lost at a realistic budget"
+        assert reduced.sizes[TEMPORAL_AXIS] == n_lineouts
+        assert reduced.size <= budget
+
+    def test_residual_is_derived_from_data_minus_fit(self, dataset_service, one_d_run):
+        """Residual is not stored, so it must be computed as data - fit.
+
+        Compared with a tolerance, not exactly: the residual is differenced at
+        full precision server-side and only then trimmed to the wire's
+        significant digits, so it is not the difference of the two rounded
+        arrays this test also fetches.
+        """
+        data = dataset_service.spectrogram(one_d_run, which="ele", field="data", max_px=None)
+        fit = dataset_service.spectrogram(one_d_run, which="ele", field="fit", max_px=None)
+        residual = dataset_service.spectrogram(one_d_run, which="ele", field="residual", max_px=None)
+
+        expected = np.array(data.values, dtype=float) - np.array(fit.values, dtype=float)
+        # Measured deviation is ~9e-6 absolute / 7e-5 relative, the double-rounding
+        # floor at magnitude ~1. A genuinely wrong residual would be off by ~0.1.
+        assert np.allclose(np.array(residual.values, dtype=float), expected, rtol=1e-3, atol=1e-5)
+
+    def test_ion_spectrum_is_servable(self, dataset_client, one_d_run):
+        assert dataset_client.get(f"/api/runs/{one_d_run}/spectrogram?which=ion").status_code == 200
+
+    def test_unknown_field_is_a_400_with_a_reason(self, dataset_client, one_d_run):
+        response = dataset_client.get(f"/api/runs/{one_d_run}/spectrogram?field=irf")
+        assert response.status_code == 400
+        assert response.json()["detail"]["reason"] == "field_unavailable"
+
+    def test_unknown_spectrum_is_a_400_with_a_reason(self, dataset_client, one_d_run):
+        response = dataset_client.get(f"/api/runs/{one_d_run}/spectrogram?which=nope")
+        assert response.status_code == 400
+        assert response.json()["detail"]["reason"] == "dataset_missing"
+
+    def test_angular_run_is_a_409_with_a_reason(self, dataset_client, angular_run):
+        response = dataset_client.get(f"/api/runs/{angular_run}/spectrogram")
+        assert response.status_code == 409
+        assert response.json()["detail"]["reason"] == "angular_not_supported"
+
+    def test_missing_dataset_is_a_404_with_a_reason(self, dataset_client, bare_run):
+        response = dataset_client.get(f"/api/runs/{bare_run}/spectrogram")
+        assert response.status_code == 404
+        assert response.json()["detail"]["reason"] == "dataset_missing"
+
+    def test_absent_requested_spectrum_is_a_404(self, fake_client, dataset_client, tmp_path):
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {"binary/ele_fit_and_data.nc": write_spectrum(tmp_path / "e", "ele_fit_and_data.nc")},
+        )
+        response = dataset_client.get("/api/runs/run-abc/spectrogram?which=ion")
+        assert response.status_code == 404
+
+
+class TestNonFiniteValues:
+    def test_nan_and_inf_serialize_as_null(self, fake_client, dataset_client, tmp_path):
+        """JSON has no NaN; a bare NaN makes browser JSON.parse throw."""
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {
+                "binary/ele_fit_and_data.nc": write_spectrum(
+                    tmp_path / "nan", "ele_fit_and_data.nc", with_nan=True
+                )
+            },
+        )
+        response = dataset_client.get("/api/runs/run-abc/spectrogram?field=data&max_px=100000")
+        assert response.status_code == 200
+        assert "NaN" not in response.text and "Infinity" not in response.text
+        assert response.json()["values"][0][0] is None
+
+    def test_inf_in_the_fit_also_becomes_null(self, fake_client, dataset_client, tmp_path):
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {
+                "binary/ele_fit_and_data.nc": write_spectrum(
+                    tmp_path / "inf", "ele_fit_and_data.nc", with_nan=True
+                )
+            },
+        )
+        body = dataset_client.get("/api/runs/run-abc/lineout?index=1&which=ele").json()
+        assert body["fit"][2] is None
+
+
+class TestLineout:
+    def test_returns_measured_and_fitted_spectrum(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/lineout?which=ele&index=2").json()
+        assert body["index"] == 2
+        assert body["lineout_count"] == 6
+        assert body["x_label"] == TEMPORAL_AXIS
+        assert len(body["wavelength"]) == 32
+        assert len(body["data"]) == len(body["fit"]) == len(body["residual"]) == 32
+
+    def test_x_value_locates_the_lineout_on_its_axis(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/lineout?index=0").json()
+        assert body["x_value"] == pytest.approx(-100.0)
+
+    def test_residual_matches_data_minus_fit(self, dataset_client, one_d_run):
+        # Tolerance rather than equality: see the spectrogram equivalent -- the
+        # residual is differenced before the wire rounding, not after it.
+        body = dataset_client.get(f"/api/runs/{one_d_run}/lineout?index=3").json()
+        expected = np.array(body["data"], dtype=float) - np.array(body["fit"], dtype=float)
+        assert np.allclose(np.array(body["residual"], dtype=float), expected, rtol=1e-3, atol=1e-5)
+
+    def test_negative_index_counts_from_the_end(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/lineout?index=-1").json()
+        assert body["index"] == 5
+
+    def test_components_are_empty_and_explained(self, dataset_client, one_d_run):
+        """IRF/noise aren't in the datasets, so report why instead of an empty dict."""
+        body = dataset_client.get(f"/api/runs/{one_d_run}/lineout?index=0").json()
+        assert body["components"] == {}
+        assert "not written to the netCDF" in body["components_unavailable"]
+
+    def test_out_of_range_index_is_a_400_with_a_reason(self, dataset_client, one_d_run):
+        response = dataset_client.get(f"/api/runs/{one_d_run}/lineout?index=99")
+        assert response.status_code == 400
+        assert response.json()["detail"]["reason"] == "index_out_of_range"
+
+    def test_angular_run_is_refused(self, dataset_client, angular_run):
+        response = dataset_client.get(f"/api/runs/{angular_run}/lineout")
+        assert response.status_code == 409
+        assert response.json()["detail"]["reason"] == "angular_not_supported"
+
+
+class TestProfiles:
+    def test_returns_one_series_per_fitted_parameter(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/profiles").json()
+        assert body["x_label"] == TEMPORAL_AXIS
+        assert len(body["x"]) == 6
+        assert {s["name"] for s in body["series"]} == {"Te_electron", "ne_electron", "amp1_general"}
+
+    def test_index_column_from_to_csv_is_not_mistaken_for_a_parameter(self, dataset_client, one_d_run):
+        """to_csv writes the DataFrame index as a leading unnamed column."""
+        names = {s["name"] for s in dataset_client.get(f"/api/runs/{one_d_run}/profiles").json()["series"]}
+        assert not any(name.startswith("Unnamed") for name in names)
+
+    def test_lineout_pixels_are_surfaced_separately(self, dataset_client, one_d_run):
+        body = dataset_client.get(f"/api/runs/{one_d_run}/profiles").json()
+        assert body["lineout_pixels"] == [800, 801, 802, 803, 804, 805]
+        assert "lineout pixel" not in {s["name"] for s in body["series"]}
+
+    def test_sigmas_are_attached_where_available(self, dataset_client, one_d_run):
+        """sigmas.nc lives at the artifact root, not under binary/."""
+        body = dataset_client.get(f"/api/runs/{one_d_run}/profiles").json()
+        assert body["sigmas_available"] is True
+        by_name = {s["name"]: s for s in body["series"]}
+        assert by_name["Te_electron"]["sigma"] == [pytest.approx(0.05)] * 6
+        assert by_name["amp1_general"]["sigma"] is None, "no sigma logged for this parameter"
+
+    def test_absent_sigmas_are_not_an_error(self, fake_client, dataset_client, tmp_path):
+        """calc_sigmas is off by default, so most runs have none."""
+        from .fixtures import learned_parameters_csv
+
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {
+                "binary/ele_fit_and_data.nc": write_spectrum(tmp_path / "e", "ele_fit_and_data.nc"),
+                "csv/learned_parameters.csv": learned_parameters_csv(),
+            },
+        )
+        body = dataset_client.get("/api/runs/run-abc/profiles").json()
+        assert body["sigmas_available"] is False
+        assert all(series["sigma"] is None for series in body["series"])
+
+    def test_missing_csv_is_a_404_with_a_reason(self, fake_client, dataset_client, tmp_path):
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {"binary/ele_fit_and_data.nc": write_spectrum(tmp_path / "e", "ele_fit_and_data.nc")},
+        )
+        response = dataset_client.get("/api/runs/run-abc/profiles")
+        assert response.status_code == 404
+        assert response.json()["detail"]["reason"] == "dataset_missing"
+
+    def test_angular_run_is_refused_before_reading_its_axis_less_csv(self, dataset_client, angular_run):
+        """Angular skips the axis insert, so profiles have no x axis at all."""
+        response = dataset_client.get(f"/api/runs/{angular_run}/profiles")
+        assert response.status_code == 409
+        assert response.json()["detail"]["reason"] == "angular_not_supported"
+
+
+class TestOpenApi:
+    def test_dataset_endpoints_are_in_the_schema(self, dataset_client):
+        paths = dataset_client.get("/api/openapi.json").json()["paths"]
+        assert {
+            "/api/runs/{run_id}/datasets",
+            "/api/runs/{run_id}/spectrogram",
+            "/api/runs/{run_id}/lineout",
+            "/api/runs/{run_id}/profiles",
+        } <= set(paths)
+
+    def test_error_bodies_document_the_reason_code(self, dataset_client):
+        schema = dataset_client.get("/api/openapi.json").json()
+        responses = schema["paths"]["/api/runs/{run_id}/spectrogram"]["get"]["responses"]
+        assert {"400", "404", "409"} <= set(responses)
+        assert "DatasetUnavailableResponse" in str(responses)
+
+
+class TestWireFormat:
+    def test_default_budget_does_not_ship_full_resolution(self, fake_client, dataset_client, tmp_path):
+        """#30: 'Never ship full resolution by default.'
+
+        A realistic spectrogram is 60 x 1024 = 61440 points, so the default
+        budget has to sit below that rather than merely capping pathological
+        cases.
+        """
+        install_artifacts(
+            fake_client,
+            "run-abc",
+            {
+                "binary/ele_fit_and_data.nc": write_spectrum(
+                    tmp_path / "big", "ele_fit_and_data.nc", n_lineouts=60, n_wavelength=1024
+                )
+            },
+        )
+        body = dataset_client.get("/api/runs/run-abc/spectrogram").json()
+        assert body["full_shape"] == [60, 1024]
+        assert body["downsample_method"] == "mean"
+        assert body["returned_shape"][0] == 60, "still without sacrificing lineouts"
+        assert body["returned_shape"][0] * body["returned_shape"][1] < 60 * 1024
+
+    def test_values_are_trimmed_to_significant_digits(self, dataset_client, one_d_run):
+        """Full float repr roughly doubles the payload for precision no plot shows."""
+        body = dataset_client.get(f"/api/runs/{one_d_run}/spectrogram?max_px=100000").json()
+        flat = [value for row in body["values"] for value in row if value is not None]
+        assert flat, "expected some values"
+        assert all(len(repr(value).split(".")[-1].rstrip("0")) <= 8 for value in flat)
+
+    def test_rounding_preserves_zero_and_sign(self):
+        from tsadar_browser.datasets import _round_significant
+
+        result = _round_significant(np.array([0.0, -1234.56789, 1e-30]), 6)
+        assert result[0] == 0.0
+        assert result[1] == pytest.approx(-1234.57)
+        assert result[2] == pytest.approx(1e-30)

--- a/tsadar_browser/app.py
+++ b/tsadar_browser/app.py
@@ -10,7 +10,7 @@ import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routes import experiments, health, runs
+from .routes import datasets, experiments, health, runs
 from .settings import get_settings
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix="/api")
     app.include_router(experiments.router, prefix="/api")
     app.include_router(runs.router, prefix="/api")
+    app.include_router(datasets.router, prefix="/api")
 
     logger.info("browser API configured against %s", settings.mlflow_tracking_uri)
     return app

--- a/tsadar_browser/datasets.py
+++ b/tsadar_browser/datasets.py
@@ -156,13 +156,26 @@ class DatasetService:
     def _artifact_paths(self, run_id: str) -> set[str]:
         return {entry.path for entry in self.gateway.list_artifacts(run_id) if not entry.is_dir}
 
+    def _binary_paths(self, run_id: str) -> set[str]:
+        """List only ``binary/``, which is all that determines the dataset kind.
+
+        Walking the whole artifact tree costs one MLflow round trip per directory
+        (``binary/``, ``csv/``, ``plots/``, ``lineouts/``, ``best/``, ``worst/``)
+        before a single byte of data is read. The lineout scrubber steps through
+        lineouts interactively, so that walk would be paid on every step.
+        """
+        return {entry.path for entry in self.gateway.list_artifacts(run_id, "binary") if not entry.is_dir}
+
     def classify(self, run_id: str, paths: set[str] | None = None) -> tuple[DatasetKind, list[str]]:
         """Return the run's dataset kind and which 1D spectra it has.
 
         Artifact shape is the authority here, not the logged ``spectype`` param --
         that is written before the fit runs and can disagree with reality.
+
+        Pass ``paths`` when a full artifact listing is already in hand (as
+        :meth:`describe` has); otherwise only ``binary/`` is listed.
         """
-        paths = self._artifact_paths(run_id) if paths is None else paths
+        paths = self._binary_paths(run_id) if paths is None else paths
 
         present = [which for which, path in ONE_D_DATASETS.items() if path in paths]
         if present:
@@ -423,7 +436,10 @@ class DatasetService:
     # -- profiles -------------------------------------------------------------
 
     def profiles(self, run_id: str) -> Profiles:
-        self._require_one_d(run_id)
+        present = self._require_one_d(run_id)
+        # Ask the dataset what its lineout axis is called, so the CSV column can
+        # be matched by name instead of guessed from column order.
+        axis_hint = self._axis_hint(run_id, present)
 
         try:
             local = self.gateway.download_artifact(run_id, LEARNED_PARAMS_CSV)
@@ -448,7 +464,7 @@ class DatasetService:
         if LINEOUT_PIXEL_COLUMN in frame.columns:
             lineout_pixels = [int(value) for value in frame.pop(LINEOUT_PIXEL_COLUMN).to_numpy()]
 
-        x_label = self._profile_axis_column(frame)
+        x_label = self._profile_axis_column(frame, axis_hint)
         if x_label is None:
             # Angular runs skip the axis insert entirely, so there is nothing to
             # plot profiles against. _require_one_d should have caught it already.
@@ -477,15 +493,42 @@ class DatasetService:
             sigmas_available=bool(sigmas),
         )
 
+    def _axis_hint(self, run_id: str, present: list[str]) -> str | None:
+        """The lineout axis name according to the netCDF, when one is readable."""
+        for which in present:
+            try:
+                with self._open(run_id, which) as dataset:
+                    return self._axes(dataset)[0]
+            except DatasetUnavailable:
+                continue
+        return None
+
     @staticmethod
-    def _profile_axis_column(frame: pd.DataFrame) -> str | None:
+    def _profile_axis_column(frame: pd.DataFrame, axis_hint: str | None = None) -> str | None:
         """Find the lineout-axis column among the parameter columns.
 
-        Axis labels carry units in parentheses (``Time (ps)``, ``Radius (\\mum)``)
-        while parameter columns are ``<param>_<species>``, so the parenthesis is
-        the discriminator.
+        Prefers an exact match against the dataset's own axis name. Falling back
+        to "first column containing a parenthesis" is positional and only safe
+        because ``get_final_params`` inserts the axis ahead of the parameters: a
+        fitted parameter that ever acquired a unit in its name would otherwise be
+        mistaken for the axis and popped out of the series. Among parenthesized
+        candidates, prefer a monotonic one, since a lineout axis always is and a
+        parameter generally is not.
         """
-        return next((str(column) for column in frame.columns if "(" in str(column)), None)
+        columns = [str(column) for column in frame.columns]
+
+        if axis_hint and axis_hint in columns:
+            return axis_hint
+
+        candidates = [column for column in columns if "(" in column]
+        if not candidates:
+            return None
+
+        for column in candidates:
+            values = pd.to_numeric(frame[column], errors="coerce").to_numpy()
+            if np.all(np.diff(values) > 0) or np.all(np.diff(values) < 0):
+                return column
+        return candidates[0]
 
     def _read_sigmas(self, run_id: str) -> dict[str, np.ndarray]:
         """Read per-parameter uncertainties, if the run computed any.
@@ -506,8 +549,11 @@ class DatasetService:
 
     # -- guards ---------------------------------------------------------------
 
-    def _require_one_d(self, run_id: str) -> None:
-        """Refuse angular and pre-contract runs before touching any dataset."""
+    def _require_one_d(self, run_id: str) -> list[str]:
+        """Refuse angular and pre-contract runs before touching any dataset.
+
+        Returns the available 1D spectra so callers do not have to classify twice.
+        """
         kind, present = self.classify(run_id)
 
         if kind is DatasetKind.angular:
@@ -524,6 +570,7 @@ class DatasetService:
                 UnavailableReason.dataset_missing,
                 "This run has no readable fit/data datasets; use the plot gallery instead.",
             )
+        return present
 
 
 def local_dataset_path(gateway: MlflowGateway, run_id: str, which: str) -> Path:  # pragma: no cover

--- a/tsadar_browser/datasets.py
+++ b/tsadar_browser/datasets.py
@@ -1,0 +1,531 @@
+"""Reading and slicing the ``binary/*.nc`` analysis datasets.
+
+This is the layer that lets the browser render from the real arrays instead of
+the pre-rendered PNGs. It reads with xarray, downsamples server-side, and refuses
+in a structured way whenever a run cannot honestly be served.
+
+Scope: **1D Thomson only** (temporal and spatial/imaging). Angular runs write a
+differently-shaped dataset and are out of scope -- see issue #37. Detecting them
+matters more than it looks: an angular ``binary/fit_and_data.nc`` holds the same
+two variables with the same dimensionality as a 1D ``ele_fit_and_data.nc``, so
+treating one as a fallback for the other would quietly serve
+angle-versus-wavelength data to a UI labelling its x-axis as time.
+
+What the datasets actually contain, from ``tsadar/utils/plotting/plotters.py``:
+
+- ``binary/ele_fit_and_data.nc`` / ``binary/ion_fit_and_data.nc`` -- variables
+  ``fit`` and ``data`` only, dims ``(<x_label>, "Wavelength")``. The x dimension
+  name is dynamic: ``Time (ps)`` or ``Radius (\\mum)``.
+- ``binary/fit_and_data.nc`` -- the angular equivalent, x dim
+  ``Scattering angle (degrees)``.
+- ``sigmas.nc`` at the artifact **root** (not under ``binary/``), variables named
+  ``<param>_<species>``.
+- ``csv/learned_parameters.csv`` -- an unnamed index column, ``lineout pixel``,
+  the x axis column, then one column per fitted parameter.
+
+Residual is derived as ``data - fit``. IRF and noise components are genuinely
+**not** in these files -- they exist only baked into the ``lineouts/``, ``best/``
+and ``worst/`` PNGs -- so they are reported as unavailable rather than invented.
+"""
+
+import logging
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from .gateway import MlflowGateway
+from .schemas import (
+    DatasetAvailability,
+    DatasetKind,
+    Lineout,
+    ProfileSeries,
+    Profiles,
+    Spectrogram,
+    SpectrumInfo,
+    UnavailableReason,
+)
+
+logger = logging.getLogger(__name__)
+
+#: 1D spectrum datasets, keyed by the ``which`` query value.
+ONE_D_DATASETS = {
+    "ele": "binary/ele_fit_and_data.nc",
+    "ion": "binary/ion_fit_and_data.nc",
+}
+
+#: The angular dataset. Recognized so it can be refused, never served.
+ANGULAR_DATASET = "binary/fit_and_data.nc"
+
+LEARNED_PARAMS_CSV = "csv/learned_parameters.csv"
+
+#: ``save_sigmas_params`` writes this to the artifact root, not under binary/.
+SIGMAS_PATHS = ("sigmas.nc", "binary/sigma-params.nc")
+
+WAVELENGTH_DIM = "Wavelength"
+LINEOUT_PIXEL_COLUMN = "lineout pixel"
+
+#: Substring identifying an angular x axis, as a second line of defense behind
+#: the artifact-shape check.
+ANGULAR_AXIS_MARKERS = ("angle", "degrees")
+
+#: Fields the spectrogram endpoint can serve. ``residual`` is derived.
+SPECTROGRAM_FIELDS = ("data", "fit", "residual")
+
+#: Why IRF is not offered. Reported rather than silently omitted.
+IRF_UNAVAILABLE = (
+    "IRF and noise components are not written to the netCDF datasets -- plotters.py "
+    "stores only 'fit' and 'data'. They exist only inside the pre-rendered lineout PNGs. "
+    "See ergodicio/tsadar#116."
+)
+
+#: Default pixel budget. Deliberately below a realistic full-resolution
+#: spectrogram (60 lineouts x 1024 wavelength pixels = 61440) so that, per #30,
+#: full resolution is never shipped unless a client asks for it by raising
+#: max_px. A heatmap panel is a few hundred pixels tall, so 1024 spectral points
+#: are already oversampled for display.
+DEFAULT_MAX_PX = 20_000
+
+#: Significant digits kept on the wire. Full float repr costs roughly twice the
+#: bytes for precision no plot can show; 6 digits is far beyond display
+#: resolution but keeps a 60x256 spectrogram near 130 KB instead of 290 KB.
+#: Clients needing exact stored values should fetch the .nc through the artifact
+#: passthrough instead.
+WIRE_SIGNIFICANT_DIGITS = 6
+
+
+class DatasetUnavailable(Exception):
+    """A run cannot be served, for a reason the frontend should act on.
+
+    Carries a machine-readable ``reason`` so #32 can distinguish "angular run,
+    interactive views not supported" from "no data found" -- the second reads as
+    a bug when shown for the first.
+    """
+
+    def __init__(self, reason: UnavailableReason, message: str, status_code: int = 404):
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+        self.status_code = status_code
+
+
+def _round_significant(array: np.ndarray, digits: int) -> np.ndarray:
+    """Round to a number of significant digits, leaving zeros and non-finites alone.
+
+    Significant digits rather than decimal places because spectra and fitted
+    parameters span very different magnitudes.
+    """
+    result = np.array(array, dtype=float, copy=True)
+    adjustable = np.isfinite(result) & (result != 0)
+    if not adjustable.any():
+        return result
+
+    magnitude = np.floor(np.log10(np.abs(result[adjustable])))
+    factor = np.power(10.0, digits - 1 - magnitude)
+    result[adjustable] = np.round(result[adjustable] * factor) / factor
+    return result
+
+
+def _json_safe(values: np.ndarray, digits: int = WIRE_SIGNIFICANT_DIGITS) -> Any:
+    """Convert an array to nested lists, JSON-safe and trimmed to ``digits``.
+
+    JSON has no NaN or Infinity. Python's ``json.dumps`` emits bare ``NaN``,
+    which is invalid JSON and makes browser ``JSON.parse`` throw, so gaps in the
+    fit have to become ``null`` before serialization.
+    """
+    array = _round_significant(np.asarray(values, dtype=float), digits)
+    return np.where(np.isfinite(array), array, None).tolist()
+
+
+def _is_angular_axis(name: str) -> bool:
+    lowered = name.lower()
+    return any(marker in lowered for marker in ANGULAR_AXIS_MARKERS)
+
+
+class DatasetService:
+    """Serves slices of a run's analysis datasets."""
+
+    def __init__(self, gateway: MlflowGateway):
+        self.gateway = gateway
+
+    # -- discovery ------------------------------------------------------------
+
+    def _artifact_paths(self, run_id: str) -> set[str]:
+        return {entry.path for entry in self.gateway.list_artifacts(run_id) if not entry.is_dir}
+
+    def classify(self, run_id: str, paths: set[str] | None = None) -> tuple[DatasetKind, list[str]]:
+        """Return the run's dataset kind and which 1D spectra it has.
+
+        Artifact shape is the authority here, not the logged ``spectype`` param --
+        that is written before the fit runs and can disagree with reality.
+        """
+        paths = self._artifact_paths(run_id) if paths is None else paths
+
+        present = [which for which, path in ONE_D_DATASETS.items() if path in paths]
+        if present:
+            return DatasetKind.one_d, present
+        if ANGULAR_DATASET in paths:
+            return DatasetKind.angular, []
+        return DatasetKind.unknown, []
+
+    def describe(self, run_id: str) -> DatasetAvailability:
+        """Report what can be rendered for this run, and why not when it can't.
+
+        #32 calls this to choose a layout, so it must answer for every run --
+        including old ones and angular ones -- rather than erroring.
+        """
+        paths = self._artifact_paths(run_id)
+        kind, present = self.classify(run_id, paths)
+
+        if kind is DatasetKind.angular:
+            return DatasetAvailability(
+                kind=kind,
+                supported=False,
+                reason=UnavailableReason.angular_not_supported,
+                message=(
+                    "This is an angularly-resolved run. Interactive spectrogram, lineout and "
+                    "profile views are limited to 1D (time- or space-resolved) Thomson; the "
+                    "plot gallery for this run is still available."
+                ),
+                profiles_available=False,
+                sigmas_available=False,
+                unavailable_fields={"irf": IRF_UNAVAILABLE},
+            )
+
+        if kind is DatasetKind.unknown:
+            return DatasetAvailability(
+                kind=kind,
+                supported=False,
+                reason=UnavailableReason.dataset_missing,
+                message=(
+                    "This run has no readable fit/data datasets, which is expected for runs "
+                    "predating the artifact contract. Use the plot gallery instead."
+                ),
+                profiles_available=LEARNED_PARAMS_CSV in paths,
+                sigmas_available=any(path in paths for path in SIGMAS_PATHS),
+                unavailable_fields={"irf": IRF_UNAVAILABLE},
+            )
+
+        spectra: list[SpectrumInfo] = []
+        for which in present:
+            try:
+                spectra.append(self._describe_spectrum(run_id, which))
+            except DatasetUnavailable as exc:
+                logger.warning("could not describe %s spectrum for run %s: %s", which, run_id, exc)
+
+        return DatasetAvailability(
+            kind=kind,
+            supported=bool(spectra),
+            reason=None if spectra else UnavailableReason.dataset_unreadable,
+            message=None if spectra else "The datasets are present but could not be opened.",
+            spectra=spectra,
+            profiles_available=LEARNED_PARAMS_CSV in paths,
+            sigmas_available=any(path in paths for path in SIGMAS_PATHS),
+            unavailable_fields={"irf": IRF_UNAVAILABLE},
+        )
+
+    def _describe_spectrum(self, run_id: str, which: str) -> SpectrumInfo:
+        with self._open(run_id, which) as dataset:
+            x_label, y_label = self._axes(dataset)
+            return SpectrumInfo(
+                which=which,
+                path=ONE_D_DATASETS[which],
+                x_label=x_label,
+                y_label=y_label,
+                lineout_count=int(dataset.sizes[x_label]),
+                wavelength_count=int(dataset.sizes[y_label]),
+                fields=list(SPECTROGRAM_FIELDS),
+            )
+
+    # -- opening --------------------------------------------------------------
+
+    def _open(self, run_id: str, which: str) -> xr.Dataset:
+        if which not in ONE_D_DATASETS:
+            raise DatasetUnavailable(
+                UnavailableReason.dataset_missing,
+                f"unknown spectrum {which!r}; expected one of {sorted(ONE_D_DATASETS)}",
+                status_code=400,
+            )
+
+        path = ONE_D_DATASETS[which]
+        try:
+            local = self.gateway.download_artifact(run_id, path)
+        except Exception as exc:  # noqa: BLE001 - absent artifact is an expected outcome
+            raise DatasetUnavailable(
+                UnavailableReason.dataset_missing,
+                f"run has no {path}: {exc}",
+            ) from exc
+
+        try:
+            dataset = xr.open_dataset(local)
+        except Exception as exc:  # noqa: BLE001 - corrupt or non-netCDF payload
+            raise DatasetUnavailable(
+                UnavailableReason.dataset_unreadable,
+                f"could not open {path} as a netCDF dataset: {exc}",
+            ) from exc
+
+        missing = {"fit", "data"} - set(dataset.data_vars)
+        if missing:
+            dataset.close()
+            raise DatasetUnavailable(
+                UnavailableReason.unexpected_schema,
+                f"{path} is missing expected variables: {sorted(missing)}",
+            )
+        return dataset
+
+    @staticmethod
+    def _axes(dataset: xr.Dataset) -> tuple[str, str]:
+        """Return ``(x_dim, wavelength_dim)``, rejecting angular data.
+
+        The x dimension name is dynamic, so it is whichever dim is not the
+        wavelength axis rather than a fixed string.
+        """
+        dims = list(dataset["data"].dims)
+        if len(dims) != 2:
+            raise DatasetUnavailable(
+                UnavailableReason.unexpected_schema,
+                f"expected a 2D fit/data array, got dims {dims}",
+            )
+
+        y_label = WAVELENGTH_DIM if WAVELENGTH_DIM in dims else str(dims[1])
+        x_label = str(next(dim for dim in dims if dim != y_label))
+
+        if _is_angular_axis(x_label):
+            # Reached only if a 1D-named file carries an angular axis; the
+            # artifact-shape check normally catches this first.
+            raise DatasetUnavailable(
+                UnavailableReason.angular_not_supported,
+                f"dataset x axis {x_label!r} is angular; interactive views are 1D only",
+                status_code=409,
+            )
+        return x_label, y_label
+
+    @staticmethod
+    def _field(dataset: xr.Dataset, field: str) -> xr.DataArray:
+        if field == "residual":
+            # Not stored: plotters.py writes only fit and data.
+            return dataset["data"] - dataset["fit"]
+        if field not in SPECTROGRAM_FIELDS:
+            raise DatasetUnavailable(
+                UnavailableReason.field_unavailable,
+                f"unknown field {field!r}; expected one of {list(SPECTROGRAM_FIELDS)}",
+                status_code=400,
+            )
+        return dataset[field]
+
+    # -- spectrogram ----------------------------------------------------------
+
+    def spectrogram(self, run_id: str, which: str, field: str, max_px: int | None) -> Spectrogram:
+        self._require_one_d(run_id)
+
+        with self._open(run_id, which) as dataset:
+            x_label, y_label = self._axes(dataset)
+            array = self._field(dataset, field)
+
+            full_shape = [int(array.sizes[x_label]), int(array.sizes[y_label])]
+            reduced, factors = self._downsample(array, x_label, y_label, max_px)
+
+            # Transpose to (wavelength, x) so `values` is directly usable as a
+            # Plotly heatmap `z`, which is indexed [y][x].
+            oriented = reduced.transpose(y_label, x_label)
+
+            return Spectrogram(
+                which=which,
+                field=field,
+                x_label=x_label,
+                y_label=y_label,
+                x=_json_safe(reduced.coords[x_label].values),
+                y=_json_safe(reduced.coords[y_label].values),
+                values=_json_safe(oriented.values),
+                full_shape=full_shape,
+                returned_shape=[int(reduced.sizes[x_label]), int(reduced.sizes[y_label])],
+                downsample_factors={"x": factors[0], "wavelength": factors[1]},
+                downsample_method="mean" if max(factors) > 1 else "none",
+            )
+
+    @staticmethod
+    def _downsample(
+        array: xr.DataArray, x_label: str, y_label: str, max_px: int | None
+    ) -> tuple[xr.DataArray, tuple[int, int]]:
+        """Block-average down to a pixel budget, sparing the lineout axis.
+
+        Wavelength is coarsened first and the lineout axis only if that is not
+        enough. Each lineout is a distinct fit with its own parameters and is what
+        the scrubber in #32 steps through, so throwing lineouts away to save
+        bytes would cost far more than reducing spectral resolution. Mean rather
+        than decimation, so a narrow spectral feature is attenuated rather than
+        skipped entirely.
+        """
+        if max_px is None or array.size <= max_px:
+            return array, (1, 1)
+
+        n_x = int(array.sizes[x_label])
+        n_y = int(array.sizes[y_label])
+
+        y_factor = min(n_y, max(1, math.ceil(n_x * n_y / max_px)))
+
+        # Integer division means the first estimate can land just over budget
+        # (60x1024 to 2000 gives 60x34 = 2040). Tighten wavelength the rest of
+        # the way before giving up any lineouts, since one more step of spectral
+        # averaging is far cheaper than losing whole fits.
+        while y_factor < n_y and n_x * math.ceil(n_y / y_factor) > max_px:
+            y_factor += 1
+
+        x_factor = 1
+        if n_x * math.ceil(n_y / y_factor) > max_px:
+            x_factor = max(1, math.ceil(n_x * math.ceil(n_y / y_factor) / max_px))
+
+        windows = {dim: factor for dim, factor in ((x_label, x_factor), (y_label, y_factor)) if factor > 1}
+        if not windows:
+            return array, (1, 1)
+
+        # boundary="trim" would silently drop a partial trailing block; "pad"
+        # keeps it and averages over the values that exist.
+        reduced = array.coarsen(windows, boundary="pad").mean()
+        return reduced, (x_factor, y_factor)
+
+    # -- lineout --------------------------------------------------------------
+
+    def lineout(self, run_id: str, which: str, index: int) -> Lineout:
+        self._require_one_d(run_id)
+
+        with self._open(run_id, which) as dataset:
+            x_label, y_label = self._axes(dataset)
+            count = int(dataset.sizes[x_label])
+            if not -count <= index < count:
+                raise DatasetUnavailable(
+                    UnavailableReason.index_out_of_range,
+                    f"lineout index {index} out of range; run has {count} lineouts",
+                    status_code=400,
+                )
+
+            data = dataset["data"].isel({x_label: index})
+            fit = dataset["fit"].isel({x_label: index})
+
+            return Lineout(
+                which=which,
+                index=index if index >= 0 else count + index,
+                lineout_count=count,
+                x_label=x_label,
+                x_value=float(dataset.coords[x_label].values[index]),
+                y_label=y_label,
+                wavelength=_json_safe(data.coords[y_label].values),
+                data=_json_safe(data.values),
+                fit=_json_safe(fit.values),
+                residual=_json_safe((data - fit).values),
+                components={},
+                components_unavailable=IRF_UNAVAILABLE,
+            )
+
+    # -- profiles -------------------------------------------------------------
+
+    def profiles(self, run_id: str) -> Profiles:
+        self._require_one_d(run_id)
+
+        try:
+            local = self.gateway.download_artifact(run_id, LEARNED_PARAMS_CSV)
+        except Exception as exc:  # noqa: BLE001
+            raise DatasetUnavailable(
+                UnavailableReason.dataset_missing,
+                f"run has no {LEARNED_PARAMS_CSV}: {exc}",
+            ) from exc
+
+        try:
+            frame = pd.read_csv(local)
+        except Exception as exc:  # noqa: BLE001
+            raise DatasetUnavailable(
+                UnavailableReason.dataset_unreadable,
+                f"could not parse {LEARNED_PARAMS_CSV}: {exc}",
+            ) from exc
+
+        # to_csv writes the DataFrame index as a leading unnamed column.
+        frame = frame.drop(columns=[column for column in frame.columns if str(column).startswith("Unnamed")])
+
+        lineout_pixels = None
+        if LINEOUT_PIXEL_COLUMN in frame.columns:
+            lineout_pixels = [int(value) for value in frame.pop(LINEOUT_PIXEL_COLUMN).to_numpy()]
+
+        x_label = self._profile_axis_column(frame)
+        if x_label is None:
+            # Angular runs skip the axis insert entirely, so there is nothing to
+            # plot profiles against. _require_one_d should have caught it already.
+            raise DatasetUnavailable(
+                UnavailableReason.unexpected_schema,
+                f"{LEARNED_PARAMS_CSV} has no lineout axis column, so profiles have no x axis",
+            )
+
+        x_values = frame.pop(x_label).to_numpy()
+        sigmas = self._read_sigmas(run_id)
+
+        series = [
+            ProfileSeries(
+                name=str(column),
+                values=_json_safe(frame[column].to_numpy()),
+                sigma=_json_safe(sigmas[str(column)]) if str(column) in sigmas else None,
+            )
+            for column in frame.columns
+        ]
+
+        return Profiles(
+            x_label=x_label,
+            x=_json_safe(x_values),
+            lineout_pixels=lineout_pixels,
+            series=series,
+            sigmas_available=bool(sigmas),
+        )
+
+    @staticmethod
+    def _profile_axis_column(frame: pd.DataFrame) -> str | None:
+        """Find the lineout-axis column among the parameter columns.
+
+        Axis labels carry units in parentheses (``Time (ps)``, ``Radius (\\mum)``)
+        while parameter columns are ``<param>_<species>``, so the parenthesis is
+        the discriminator.
+        """
+        return next((str(column) for column in frame.columns if "(" in str(column)), None)
+
+    def _read_sigmas(self, run_id: str) -> dict[str, np.ndarray]:
+        """Read per-parameter uncertainties, if the run computed any.
+
+        ``calc_sigmas`` is off by default, so absence is normal, not an error.
+        """
+        for path in SIGMAS_PATHS:
+            try:
+                local = self.gateway.download_artifact(run_id, path)
+            except Exception:  # noqa: BLE001 - try the next candidate location
+                continue
+            try:
+                with xr.open_dataset(local) as dataset:
+                    return {str(name): array.values for name, array in dataset.data_vars.items()}
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("could not read sigmas from %s for run %s: %s", path, run_id, exc)
+        return {}
+
+    # -- guards ---------------------------------------------------------------
+
+    def _require_one_d(self, run_id: str) -> None:
+        """Refuse angular and pre-contract runs before touching any dataset."""
+        kind, present = self.classify(run_id)
+
+        if kind is DatasetKind.angular:
+            raise DatasetUnavailable(
+                UnavailableReason.angular_not_supported,
+                (
+                    "This is an angularly-resolved run. Interactive views are limited to 1D "
+                    "(time- or space-resolved) Thomson; use the plot gallery for this run."
+                ),
+                status_code=409,
+            )
+        if kind is DatasetKind.unknown and not present:
+            raise DatasetUnavailable(
+                UnavailableReason.dataset_missing,
+                "This run has no readable fit/data datasets; use the plot gallery instead.",
+            )
+
+
+def local_dataset_path(gateway: MlflowGateway, run_id: str, which: str) -> Path:  # pragma: no cover
+    """Convenience for debugging: where a spectrum dataset landed on disk."""
+    return gateway.download_artifact(run_id, ONE_D_DATASETS[which])

--- a/tsadar_browser/deps.py
+++ b/tsadar_browser/deps.py
@@ -3,6 +3,7 @@
 from functools import lru_cache
 
 from .cache import ArtifactCache
+from .datasets import DatasetService
 from .gateway import MlflowGateway
 from .settings import Settings, get_settings
 
@@ -18,3 +19,8 @@ def get_gateway() -> MlflowGateway:
     settings: Settings = get_settings()
     settings.apply_to_environment()
     return MlflowGateway(settings=settings, cache=get_cache())
+
+
+@lru_cache
+def get_dataset_service() -> DatasetService:
+    return DatasetService(gateway=get_gateway())

--- a/tsadar_browser/routes/__init__.py
+++ b/tsadar_browser/routes/__init__.py
@@ -1,5 +1,5 @@
 """API routers."""
 
-from . import experiments, health, runs
+from . import datasets, experiments, health, runs
 
-__all__ = ["experiments", "health", "runs"]
+__all__ = ["datasets", "experiments", "health", "runs"]

--- a/tsadar_browser/routes/datasets.py
+++ b/tsadar_browser/routes/datasets.py
@@ -1,0 +1,136 @@
+"""Interactive plot endpoints, served from the ``binary/*.nc`` datasets.
+
+Restricted to 1D (time- and space-resolved) Thomson; angular runs are refused
+with a distinguishable reason so the client can fall back to the plot gallery
+rather than reporting an error. See issue #37.
+"""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from mlflow.exceptions import MlflowException
+
+from ..datasets import DEFAULT_MAX_PX, SPECTROGRAM_FIELDS, DatasetService, DatasetUnavailable
+from ..deps import get_dataset_service
+from ..schemas import (
+    DatasetAvailability,
+    DatasetUnavailableResponse,
+    Lineout,
+    Profiles,
+    Spectrogram,
+)
+from .runs import _reraise
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["datasets"])
+
+#: Documented on every dataset route so the generated client knows the error
+#: body carries a reason code, not just a string.
+UNAVAILABLE_RESPONSES = {
+    400: {"model": DatasetUnavailableResponse, "description": "Invalid field, spectrum or index"},
+    404: {"model": DatasetUnavailableResponse, "description": "Dataset missing or unreadable"},
+    409: {"model": DatasetUnavailableResponse, "description": "Recognized but unsupported, e.g. an angular run"},
+}
+
+
+def _unavailable(exc: DatasetUnavailable) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={"reason": exc.reason.value, "detail": exc.message},
+    )
+
+
+@router.get(
+    "/runs/{run_id}/datasets",
+    response_model=DatasetAvailability,
+    summary="What interactive views this run supports",
+)
+def get_availability(
+    run_id: str, service: Annotated[DatasetService, Depends(get_dataset_service)]
+) -> DatasetAvailability:
+    """Probe before rendering.
+
+    Always answers -- an angular or pre-contract run gets ``supported: false``
+    plus a reason rather than an error, so the run detail view can pick a layout
+    in one call.
+    """
+    try:
+        return service.describe(run_id)
+    except MlflowException as exc:
+        raise _reraise(exc, "run") from exc
+
+
+@router.get(
+    "/runs/{run_id}/spectrogram",
+    response_model=Spectrogram,
+    responses=UNAVAILABLE_RESPONSES,
+    summary="2D spectrogram, downsampled server-side",
+)
+def get_spectrogram(
+    run_id: str,
+    service: Annotated[DatasetService, Depends(get_dataset_service)],
+    which: Annotated[str, Query(description="'ele' or 'ion'")] = "ele",
+    field: Annotated[
+        str, Query(description=f"One of {list(SPECTROGRAM_FIELDS)}; 'residual' is derived as data - fit")
+    ] = "data",
+    max_px: Annotated[
+        int,
+        Query(
+            ge=1,
+            description=(
+                "Pixel budget. The array is block-averaged to at most this many points; "
+                "the lineout axis is spared where possible, so wavelength is reduced first."
+            ),
+        ),
+    ] = DEFAULT_MAX_PX,
+) -> Spectrogram:
+    try:
+        return service.spectrogram(run_id, which=which, field=field, max_px=max_px)
+    except DatasetUnavailable as exc:
+        raise _unavailable(exc) from exc
+    except MlflowException as exc:
+        raise _reraise(exc, "run") from exc
+
+
+@router.get(
+    "/runs/{run_id}/lineout",
+    response_model=Lineout,
+    responses=UNAVAILABLE_RESPONSES,
+    summary="Measured vs fitted spectrum at one lineout",
+)
+def get_lineout(
+    run_id: str,
+    service: Annotated[DatasetService, Depends(get_dataset_service)],
+    which: Annotated[str, Query(description="'ele' or 'ion'")] = "ele",
+    index: Annotated[int, Query(description="Lineout index; negative counts from the end")] = 0,
+) -> Lineout:
+    """The interactive replacement for the pre-rendered lineout PNGs.
+
+    IRF and noise components are not in the netCDF datasets, so they are reported
+    as unavailable rather than fabricated -- see ``components_unavailable``.
+    """
+    try:
+        return service.lineout(run_id, which=which, index=index)
+    except DatasetUnavailable as exc:
+        raise _unavailable(exc) from exc
+    except MlflowException as exc:
+        raise _reraise(exc, "run") from exc
+
+
+@router.get(
+    "/runs/{run_id}/profiles",
+    response_model=Profiles,
+    responses=UNAVAILABLE_RESPONSES,
+    summary="Fitted parameters vs lineout, with uncertainties where available",
+)
+def get_profiles(
+    run_id: str, service: Annotated[DatasetService, Depends(get_dataset_service)]
+) -> Profiles:
+    try:
+        return service.profiles(run_id)
+    except DatasetUnavailable as exc:
+        raise _unavailable(exc) from exc
+    except MlflowException as exc:
+        raise _reraise(exc, "run") from exc

--- a/tsadar_browser/schemas.py
+++ b/tsadar_browser/schemas.py
@@ -166,11 +166,24 @@ class UnavailableReason(str, Enum):
     index_out_of_range = "index_out_of_range"
 
 
-class DatasetUnavailableResponse(BaseModel):
-    """Error body for the dataset endpoints, carrying a reason code."""
+class DatasetUnavailableBody(BaseModel):
+    """The reason payload itself."""
 
     reason: UnavailableReason
     detail: str
+
+
+class DatasetUnavailableResponse(BaseModel):
+    """Error body for the dataset endpoints, carrying a reason code.
+
+    Nested under ``detail`` because that is what actually goes over the wire:
+    FastAPI wraps whatever an ``HTTPException`` carries in a ``detail`` key. A
+    flat declaration would make the generated client read ``err.reason`` and get
+    ``undefined`` on exactly the angular-vs-missing distinction these endpoints
+    exist to make legible.
+    """
+
+    detail: DatasetUnavailableBody
 
 
 class SpectrumInfo(BaseModel):

--- a/tsadar_browser/schemas.py
+++ b/tsadar_browser/schemas.py
@@ -6,6 +6,7 @@ optionality here are load-bearing. Prefer adding an optional field over
 changing the meaning of an existing one.
 """
 
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -131,3 +132,129 @@ class RunDetail(RunSummary):
 
 class ErrorResponse(BaseModel):
     detail: str
+
+
+# -- analysis datasets (issue #30) --------------------------------------------
+#
+# Values are plain JSON numbers. Everything is downsampled to a pixel budget
+# server-side, so the payload stays small enough that a binary format would buy
+# little and cost the codegen contract. Non-finite values (gaps in a fit) are
+# serialized as null, since JSON has no NaN and a bare NaN makes browser
+# JSON.parse throw.
+
+
+class DatasetKind(str, Enum):
+    """What kind of Thomson run the artifacts say this is."""
+
+    one_d = "one_d"
+    angular = "angular"
+    unknown = "unknown"
+
+
+class UnavailableReason(str, Enum):
+    """Machine-readable reason a dataset view cannot be served.
+
+    Distinguishing these matters: showing "no data found" for an angular run
+    reads as a bug, when the truth is that the view is deliberately out of scope.
+    """
+
+    angular_not_supported = "angular_not_supported"
+    dataset_missing = "dataset_missing"
+    dataset_unreadable = "dataset_unreadable"
+    unexpected_schema = "unexpected_schema"
+    field_unavailable = "field_unavailable"
+    index_out_of_range = "index_out_of_range"
+
+
+class DatasetUnavailableResponse(BaseModel):
+    """Error body for the dataset endpoints, carrying a reason code."""
+
+    reason: UnavailableReason
+    detail: str
+
+
+class SpectrumInfo(BaseModel):
+    which: str = Field(description="'ele' or 'ion'")
+    path: str = Field(description="Artifact path this spectrum was read from")
+    x_label: str = Field(description="Lineout axis name, e.g. 'Time (ps)' or 'Radius (\\mum)'")
+    y_label: str = Field(description="Spectral axis name, normally 'Wavelength'")
+    lineout_count: int
+    wavelength_count: int
+    fields: list[str] = Field(description="Renderable fields; 'residual' is derived as data - fit")
+
+
+class DatasetAvailability(BaseModel):
+    """What the interactive views can render for a run, and why not when they can't.
+
+    The run detail view calls this first to choose a layout, so it answers for
+    every run -- including angular and pre-contract ones -- instead of erroring.
+    """
+
+    kind: DatasetKind
+    supported: bool = Field(description="True when at least one spectrum can be served")
+    reason: UnavailableReason | None = None
+    message: str | None = Field(default=None, description="Human-readable explanation, safe to show")
+    spectra: list[SpectrumInfo] = []
+    profiles_available: bool = False
+    sigmas_available: bool = Field(
+        default=False, description="Whether uncertainties exist; calc_sigmas is off by default"
+    )
+    unavailable_fields: dict[str, str] = Field(
+        default_factory=dict,
+        description="Fields a client might expect but which cannot be served, mapped to why",
+    )
+
+
+class Spectrogram(BaseModel):
+    which: str
+    field: str = Field(description="'data', 'fit', or the derived 'residual'")
+    x_label: str
+    y_label: str
+    x: list[float | None] = Field(description="Lineout axis coordinates")
+    y: list[float | None] = Field(description="Wavelength coordinates")
+    values: list[list[float | None]] = Field(
+        description="Shape (len(y), len(x)) -- row-major by wavelength, directly usable as a Plotly heatmap z"
+    )
+    full_shape: list[int] = Field(description="[lineouts, wavelengths] before downsampling")
+    returned_shape: list[int] = Field(description="[lineouts, wavelengths] as returned")
+    downsample_factors: dict[str, int] = Field(
+        description="Block-averaging factors applied per axis. The lineout axis is spared where possible."
+    )
+    downsample_method: str = Field(description="'mean' when downsampled, 'none' when full resolution")
+
+
+class Lineout(BaseModel):
+    which: str
+    index: int = Field(description="Resolved lineout index; negative inputs are normalized")
+    lineout_count: int
+    x_label: str
+    x_value: float = Field(description="Position of this lineout on the lineout axis")
+    y_label: str
+    wavelength: list[float | None]
+    data: list[float | None] = Field(description="Measured spectrum")
+    fit: list[float | None] = Field(description="Fitted spectrum")
+    residual: list[float | None] = Field(description="Derived as data - fit")
+    components: dict[str, list[float | None]] = Field(
+        default_factory=dict, description="Always empty today; see components_unavailable"
+    )
+    components_unavailable: str | None = Field(
+        default=None, description="Why IRF/noise components are absent, when they are"
+    )
+
+
+class ProfileSeries(BaseModel):
+    name: str = Field(description="Column name from learned_parameters.csv, e.g. 'Te_electron'")
+    values: list[float | None]
+    sigma: list[float | None] | None = Field(
+        default=None, description="Per-point uncertainty when the run computed sigmas"
+    )
+
+
+class Profiles(BaseModel):
+    x_label: str
+    x: list[float | None] = Field(description="Lineout axis coordinates")
+    lineout_pixels: list[int] | None = Field(
+        default=None, description="Detector pixel index per lineout, when logged"
+    )
+    series: list[ProfileSeries]
+    sigmas_available: bool


### PR DESCRIPTION
Closes #30. Third PR against #37, building on #29's artifact cache. This is the piece that makes the browser better than browsing PNGs: it renders from the arrays the fit actually produced.

Scoped to 1D Thomson per the decision on #37 — angular runs are refused, never served.

## Endpoints

| Endpoint | Notes |
| --- | --- |
| `GET /api/runs/{id}/datasets` | Capability probe — what this run supports, and why not when it doesn't |
| `GET /api/runs/{id}/spectrogram` | `which=ele\|ion`, `field=data\|fit\|residual`, `max_px=` |
| `GET /api/runs/{id}/lineout` | `which`, `index` (negative counts from the end) |
| `GET /api/runs/{id}/profiles` | Fitted parameters vs lineout, with sigmas where available |

**Probe before rendering.** `/datasets` answers for *every* run — angular, pre-contract, or fully supported — rather than erroring, so #32 can pick a layout in one call. Failures carry a machine-readable `reason` (`angular_not_supported`, `dataset_missing`, `dataset_unreadable`, `unexpected_schema`, `field_unavailable`, `index_out_of_range`), with **409** for recognized-but-unsupported and **404** for genuinely absent. That distinction is the point: showing "no data found" for an angular run reads as a bug when the view is deliberately out of scope.

## The angular check is doing real work

Worth a close look, because the failure mode is silent. An angular `binary/fit_and_data.nc` holds **the same two variables with the same dimensionality** as a 1D `ele_fit_and_data.nc`. A plausible-looking "try `fit_and_data.nc` if `ele_`/`ion_` are missing" would serve angle-vs-wavelength data to a UI labelling its x-axis as time — wrong physics, no error.

So classification is by **artifact shape**, not the logged `spectype` param (written before `fitter.fit` runs, overwritten from the data file during `prepare`, so it can lie), and the dataset's own axis name is checked as a second line of defense. Both paths are tested, including a deliberately mislabelled file and a run whose param claims `angular_full` while its artifacts are 1D.

## Two corrections to the issue's premise

Both verified in `plotters.py` rather than assumed:

- **The datasets contain only `fit` and `data`** (lines 430, 477, 506). `residual` is derived as `data - fit`.
- **IRF and noise components are not in the netCDFs at all** — they exist only baked into the pre-rendered `lineouts/`/`best/`/`worst/` PNGs. Reported through `unavailable_fields` and `components_unavailable` rather than invented. Making them genuinely available is a `plotters.py` change, probably belonging with ergodicio/tsadar#116.

## Downsampling

Block-**averaging**, not decimation, so a narrow spectral feature is attenuated rather than skipped entirely.

**Wavelength is reduced first and the lineout axis spared wherever possible.** Each lineout is a separate fit with its own parameters and is the axis #32's scrubber steps through, so trading lineouts for bytes costs far more than spectral resolution. The first factor estimate can land just over budget through integer division (60×1024 into 2000 gives 60×34 = 2040), so wavelength is tightened one more step rather than halving the lineouts:

| Shape | Budget | Returned | Lineouts kept |
| --- | --- | --- | --- |
| 60 × 1024 | 20,000 | 60 × 256 | all 60 |
| 60 × 1024 | 2,000 | 60 × 32 | all 60 |
| 300 × 1024 | 5,000 | 300 × 16 | all 300 |

`values` is shaped `(len(y), len(x))` — row-major by wavelength — so it drops straight into a Plotly heatmap `z`, which is indexed `[y][x]`.

## Wire format: plain JSON, with two details that bite

- **Non-finite values serialize as `null`.** JSON has no NaN, and Python's `json.dumps` emits a bare `NaN` that makes browser `JSON.parse` **throw** — so a run with gaps in its fit would have broken the frontend outright.
- **Values are trimmed to 6 significant digits**, halving the payload (60 × 256 goes ~290 KB → ~121 KB) for precision no plot can show. Anything needing exact stored values should fetch the `.nc` through #29's artifact passthrough.

The default `max_px` is **20,000**, deliberately below a realistic 60 × 1024 = 61,440, because the issue asks that full resolution never be shipped by default. Clients can raise it (full res measures 484 KB).

One consequence I'd rather state than have someone discover: `residual` is differenced at full precision and *then* rounded, so it isn't bit-identical to `data - fit` computed from the rounded arrays. I measured the gap rather than guessing a tolerance — 9e-6 absolute, 7e-5 relative, the double-rounding floor at these magnitudes — and the tests assert against that.

## Testing

138 passing (46 new). Fixtures reproduce what `plotters.py` actually writes, which is most of their value:

- the dynamic x axis name (`Time (ps)`, `Radius (\mum)`, `Scattering angle (degrees)`)
- `sigmas.nc` at the artifact **root**, not under `binary/`
- the unnamed index column `to_csv` prepends to `learned_parameters.csv`, and the angular variant that omits the lineout-axis column entirely

```
$ python -m pytest tests/browser -q
138 passed
```

Also exercised end-to-end through the app at realistic detector dimensions to confirm payload sizes and that no invalid JSON tokens appear.

Dependencies: `xarray`, `h5netcdf`, `h5py`, `numpy`, `pandas` added to `requirements-browser.txt` — h5netcdf rather than netCDF4 so there's no `libnetcdf` system dependency to carry into the container for #34.

One pre-existing test changed: #29's OpenAPI test asserted an *exact* path set, so it now asserts the read-layer paths are present. It's about the read layer staying available, not about the API never growing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM8XjWjnJ1iKv19BS9c9Ab)_