### PR TITLE
Browser frontend: run detail view (interactive spectrogram, lineouts, profiles, config diff)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,8 @@
 # Thomson analysis browser — frontend
 
 A Vite + React + TypeScript SPA over the read layer in `tsadar_browser/`
-([#29]). This covers the scaffold and the run browser ([#31]); the run detail view
-is [#32] and the compare view is [#33].
+([#29]). This covers the scaffold and run browser ([#31]) and the run detail view
+([#32]); the compare view is [#33].
 
 ## Running it
 
@@ -79,6 +79,43 @@ it is displayed but never used to filter.
 
 **`Radius (\mum)` is a literal LaTeX fragment** in tsadar's stored axis labels, so
 `lib/format.ts` renders it as `µm` rather than showing the backslash.
+
+## The run detail view
+
+Layout is chosen from the capability probe (`GET /api/runs/{id}/datasets`) rather
+than guessed, so a run that cannot be served interactively gets the plot gallery
+with the backend's own explanation of why. An angular run is out of scope by
+design, not broken, and the page says so instead of showing an error — and it is
+never blank.
+
+The spectrogram, lineout scrubber and profiles panels are linked through a single
+lineout index that lives in the URL, so a link can point at one specific lineout
+of one specific run. Clicking a spectrogram column, dragging the scrubber, or
+clicking a profile point all move the same marker.
+
+**Plotly is only touched in `components/Plot.tsx`.** Two reasons: it is loaded
+with a dynamic import so the run browser never pays for a charting library it
+does not use (the main bundle stays ~118 KB gzipped while Plotly is a separate
+~460 KB chunk fetched on the detail page), and panels can mock that one component
+under test. We use the **cartesian** bundle rather than the full one — it carries
+heatmap and scatter, everything these panels draw, at roughly a third the size.
+
+**There is no metric named `loss`.** The loss panel picks from what the run
+actually logged (`epoch loss`, `overall loss`, `min loss`, `batch loss` — names
+with spaces), preferring a per-step key because `overall loss` is usually a single
+summary point. Requesting a fixed `loss` key would 404 on every run.
+
+**The config diff is conditional, because the two ways of running record config
+differently.** App-queued runs log a single merged `config.yaml`, so there is
+nothing to diff and the control is disabled with an explanation. NERSC-queued runs
+log `defaults.yaml` *and* `inputs.yaml`, which diff to answer "what did this run
+actually change?" — shown changed-keys-only by default. The merged tree, rebuilt
+from logged params by the backend, is always available either way.
+
+**The gallery is always shown, not only as a fallback.** Even a fully interactive
+run has images the slicing API cannot reproduce: the distribution-function
+contours, the error histogram, and the lineout plots that *do* include IRF and
+noise components — which the netCDF datasets do not carry.
 
 ## Testing notes
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.0",
-        "plotly.js-dist-min": "^3.0.1",
+        "plotly.js-cartesian-dist-min": "^3.7.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.0"
+        "react-router-dom": "^7.6.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -2599,10 +2600,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/plotly.js-dist-min": {
+    "node_modules/plotly.js-cartesian-dist-min": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-3.7.0.tgz",
-      "integrity": "sha512-IRWNnBJZmKss3URDnicBK2nvt/VTSi/MD1GnUscAYFjwSuN6g/CTde5R1UC0RYtblehj8rkT4BL8r05e/c8j5Q==",
+      "resolved": "https://registry.npmjs.org/plotly.js-cartesian-dist-min/-/plotly.js-cartesian-dist-min-3.7.0.tgz",
+      "integrity": "sha512-kfQjcAXXByRlskP8JsrlGYRPOvB+kOehZk/qBNewgr9SOMEnBN5nwEnUGOAQ0EEgYdQX51z3VZ81aBnDgSr9Bw==",
       "license": "MIT"
     },
     "node_modules/pluralize": {
@@ -3423,6 +3424,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,10 +17,11 @@
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.0",
-    "plotly.js-dist-min": "^3.0.1",
+    "plotly.js-cartesian-dist-min": "^3.7.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,32 +1,22 @@
 /**
- * Routes. `/runs/:runId` and `/compare` are placeholders here so the URL
- * contract the run browser links into is fixed now; the views themselves land
- * with #32 and #33.
+ * Routes. `/compare` stays a placeholder so the URL contract the run browser
+ * links into is fixed; the view itself lands with #33.
  */
 
-import { Navigate, Route, Routes, useParams } from "react-router-dom";
+import { Link, Navigate, Route, Routes } from "react-router-dom";
 
 import { RunBrowser } from "./routes/RunBrowser";
+import { RunDetail } from "./routes/RunDetail";
 
 function Placeholder({ title, detail }: { title: string; detail: string }) {
   return (
     <section className="state">
       <p className="state__title">{title}</p>
       <p className="state__detail">{detail}</p>
-      <a className="button" href="/runs">
+      <Link className="button" to="/runs">
         Back to runs
-      </a>
+      </Link>
     </section>
-  );
-}
-
-function RunDetailPlaceholder() {
-  const { runId } = useParams();
-  return (
-    <Placeholder
-      title={`Run ${runId}`}
-      detail="The run detail view — spectrogram, lineout scrubber, profiles and config diff — arrives with issue #32."
-    />
   );
 }
 
@@ -36,7 +26,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<Navigate to="/runs" replace />} />
         <Route path="/runs" element={<RunBrowser />} />
-        <Route path="/runs/:runId" element={<RunDetailPlaceholder />} />
+        <Route path="/runs/:runId" element={<RunDetail />} />
         <Route
           path="/compare"
           element={

--- a/frontend/src/__tests__/Plot.test.tsx
+++ b/frontend/src/__tests__/Plot.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * The Plot wrapper itself, with Plotly mocked at the module boundary.
+ *
+ * The panel tests mock `Plot` wholesale and assert on the traces it receives,
+ * which leaves the wrapper's own lifecycle untested -- and that lifecycle is
+ * where the interesting bug was: purging on every data change destroyed the
+ * graph (losing zoom/pan) instead of letting `Plotly.react` diff it, and could
+ * race an in-flight `react` into an empty div.
+ */
+
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Plot } from "../components/Plot";
+
+const graph = {
+  on: vi.fn(),
+  removeAllListeners: vi.fn(),
+};
+
+const plotly = {
+  // Parameters are declared so `mock.calls` is typed and the assertions below can
+  // index into a call's arguments.
+  react: vi.fn(
+    async (_element: HTMLElement, _data: unknown[], _layout?: unknown, _config?: unknown) => graph,
+  ),
+  purge: vi.fn((_element: HTMLElement) => {}),
+};
+
+vi.mock("plotly.js-cartesian-dist-min", () => plotly);
+
+/** The wrapper awaits a dynamic import and then `react`, so a render is not
+ *  finished until those microtasks have drained. A macrotask boundary drains all
+ *  of them, however many the chain happens to be -- counting `Promise.resolve()`
+ *  ticks by hand makes the assertions sensitive to that depth rather than to
+ *  what the component actually did. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  plotly.react.mockClear();
+  plotly.purge.mockClear();
+  graph.on.mockClear();
+  graph.removeAllListeners.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Plot", () => {
+  it("updates in place without purging when the data changes", async () => {
+    const first = [{ y: [1, 2, 3] }];
+    const second = [{ y: [4, 5, 6] }];
+
+    const { rerender } = render(<Plot data={first} ariaLabel="chart" />);
+    await settle();
+    expect(plotly.react).toHaveBeenCalledTimes(1);
+
+    rerender(<Plot data={second} ariaLabel="chart" />);
+    await settle();
+
+    // Two `react` calls, no purge: the graph div is reused, so Plotly diffs the
+    // traces and the user's zoom and pan survive.
+    expect(plotly.react).toHaveBeenCalledTimes(2);
+    expect(plotly.react.mock.calls[1]?.[1]).toBe(second);
+    expect(plotly.purge).not.toHaveBeenCalled();
+  });
+
+  it("does not re-plot when only the click handler changes", async () => {
+    const data = [{ y: [1, 2, 3] }];
+
+    const { rerender } = render(<Plot data={data} onPointClick={() => {}} />);
+    await settle();
+
+    rerender(<Plot data={data} onPointClick={() => {}} />);
+    await settle();
+
+    expect(plotly.react).toHaveBeenCalledTimes(1);
+  });
+
+  it("purges once, on unmount", async () => {
+    const { rerender, unmount } = render(<Plot data={[{ y: [1] }]} />);
+    await settle();
+    rerender(<Plot data={[{ y: [2] }]} />);
+    await settle();
+    expect(plotly.purge).not.toHaveBeenCalled();
+
+    unmount();
+    await settle();
+    expect(plotly.purge).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces the click listener on each re-plot rather than stacking them", async () => {
+    const { rerender } = render(<Plot data={[{ y: [1] }]} onPointClick={() => {}} />);
+    await settle();
+    rerender(<Plot data={[{ y: [2] }]} onPointClick={() => {}} />);
+    await settle();
+
+    // One listener attached per `react`, each preceded by a removal, so a click
+    // fires the handler once no matter how many times the data has changed.
+    expect(graph.removeAllListeners).toHaveBeenCalledTimes(2);
+    expect(graph.on).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the clicked point index", async () => {
+    const clicked = vi.fn();
+    render(<Plot data={[{ y: [1, 2, 3] }]} onPointClick={clicked} />);
+    await settle();
+
+    const [event, handler] = graph.on.mock.calls[0] as [string, (payload: unknown) => void];
+    expect(event).toBe("plotly_click");
+
+    handler({ points: [{ pointIndex: 2 }] });
+    expect(clicked).toHaveBeenCalledWith(2);
+
+    // Plotly uses `pointNumber` for some trace types and `pointIndex` for
+    // others; heatmap clicks are how the spectrogram selects a lineout.
+    handler({ points: [{ pointNumber: 5 }] });
+    expect(clicked).toHaveBeenCalledWith(5);
+
+    // A click on empty canvas carries no point at all.
+    handler({ points: [] });
+    expect(clicked).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls the latest click handler after a re-render", async () => {
+    const stale = vi.fn();
+    const fresh = vi.fn();
+
+    const data = [{ y: [1] }];
+    const { rerender } = render(<Plot data={data} onPointClick={stale} />);
+    await settle();
+    rerender(<Plot data={data} onPointClick={fresh} />);
+    await settle();
+
+    const handler = graph.on.mock.calls[0]?.[1] as (payload: unknown) => void;
+    handler({ points: [{ pointIndex: 0 }] });
+
+    expect(stale).not.toHaveBeenCalled();
+    expect(fresh).toHaveBeenCalledWith(0);
+  });
+});

--- a/frontend/src/__tests__/RunDetail.test.tsx
+++ b/frontend/src/__tests__/RunDetail.test.tsx
@@ -1,0 +1,443 @@
+/**
+ * Run detail view (issue #32).
+ *
+ * Plotly is mocked, so the assertions are about the traces each panel builds --
+ * which is the part worth testing. Whether Plotly draws a heatmap correctly is
+ * Plotly's problem; whether we hand it the fit array when the user asked for the
+ * fit is ours.
+ */
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RunDetail } from "../routes/RunDetail";
+import {
+  angularAvailability,
+  availability,
+  lineout,
+  metricHistory,
+  profiles,
+  runDetail,
+  spectrogram,
+} from "./fixtures";
+
+// Capture what each Plot receives instead of rendering one.
+const plotCalls: Array<{ data: unknown[]; layout?: Record<string, unknown>; ariaLabel?: string }> = [];
+
+vi.mock("../components/Plot", () => ({
+  Plot: (props: { data: unknown[]; layout?: Record<string, unknown>; ariaLabel?: string }) => {
+    plotCalls.push(props);
+    return <div data-testid="plot" data-aria={props.ariaLabel} />;
+  },
+}));
+
+interface StubOptions {
+  detail?: Record<string, unknown>;
+  probe?: Record<string, unknown>;
+  spectrogramBody?: Record<string, unknown>;
+  failMetric?: boolean;
+  yaml?: Record<string, string>;
+}
+
+let requested: string[] = [];
+
+function stubApi(options: StubOptions = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      requested.push(url);
+      const ok = (body: unknown): Response =>
+        ({
+          ok: true,
+          status: 200,
+          json: async (): Promise<unknown> => body,
+          text: async (): Promise<string> => "",
+        }) as unknown as Response;
+
+      if (url.includes("/datasets")) return ok(options.probe ?? availability());
+      if (url.includes("/spectrogram")) {
+        const field = new URL(url, "http://x").searchParams.get("field") ?? "data";
+        return ok(spectrogram({ field, ...options.spectrogramBody }));
+      }
+      if (url.includes("/lineout")) {
+        const index = Number(new URL(url, "http://x").searchParams.get("index") ?? "0");
+        return ok(lineout({ index, x_value: -100 + index * 40 }));
+      }
+      if (url.includes("/profiles")) return ok(options.probe === undefined ? profiles() : profiles());
+      if (url.includes("/metrics/")) {
+        if (options.failMetric) return { ok: false, status: 404, json: async () => ({ detail: "no history" }) };
+        const key = decodeURIComponent(url.split("/metrics/")[1] ?? "");
+        return ok(metricHistory(key));
+      }
+      if (url.includes("/artifacts/")) {
+        const path = url.split("/artifacts/")[1] ?? "";
+        const text = options.yaml?.[path];
+        if (text === undefined) {
+          return { ok: false, status: 404, text: async (): Promise<string> => "" } as unknown as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          text: async (): Promise<string> => text,
+          json: async (): Promise<unknown> => ({}),
+        } as unknown as Response;
+      }
+      return ok(options.detail ?? runDetail());
+    }),
+  );
+}
+
+function renderDetail(url = "/runs/run-abc") {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/runs/:runId" element={<RunDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  plotCalls.length = 0;
+  requested = [];
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("header", () => {
+  it("shows identity, status and stage as separate badges", async () => {
+    stubApi();
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByText("shot-101675-scan")).toBeInTheDocument());
+
+    // Scoped to the run header: the shot number also appears in the config tree,
+    // and every panel has its own <header>, so anchor on the h1.
+    const header = within(
+      screen.getByRole("heading", { level: 1 }).closest("header") as HTMLElement,
+    );
+    // Two badges, not one: they answer different questions.
+    expect(header.getByText("FINISHED")).toBeInTheDocument();
+    expect(header.getByText("completed")).toBeInTheDocument();
+    expect(header.getByText("101675")).toBeInTheDocument();
+    expect(header.getByText("archis")).toBeInTheDocument();
+  });
+
+  it("names the metric its final loss came from", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByText("Final loss (overall loss)")).toBeInTheDocument());
+  });
+
+  it("links out to the raw MLflow run page", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Open in MLflow" })).toHaveAttribute(
+        "href",
+        "https://continuum.ergodic.io/experiments/#/experiments/1/runs/run-abc",
+      ),
+    );
+  });
+});
+
+describe("spectrogram panel", () => {
+  it("plots the heatmap with axis coordinates", async () => {
+    stubApi();
+    renderDetail();
+
+    await waitFor(() => expect(plotCalls.length).toBeGreaterThan(0));
+    const heatmap = plotCalls.find((call) => call.ariaLabel?.includes("spectrogram"));
+    expect(heatmap).toBeDefined();
+    const trace = heatmap!.data[0] as Record<string, unknown>;
+    expect(trace.type).toBe("heatmap");
+    expect(trace.z).toEqual(spectrogram().values);
+    expect(trace.x).toEqual(spectrogram().x);
+  });
+
+  it("offers exactly data, fit and residual -- no irf", async () => {
+    // IRF isn't in the netCDF datasets, so offering a toggle for it would
+    // promise something the backend cannot serve.
+    stubApi();
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByRole("group", { name: "Field" })).toBeInTheDocument());
+    const fields = within(screen.getByRole("group", { name: "Field" })).getAllByRole("button");
+    expect(fields.map((button) => button.textContent)).toEqual(["data", "fit", "residual"]);
+  });
+
+  it("switching to fit refetches that field", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole("group", { name: "Field" })).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "fit" }));
+    await waitFor(() => expect(requested.some((url) => url.includes("field=fit"))).toBe(true));
+  });
+
+  it("uses a diverging scale centred at zero for the signed residual", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByRole("group", { name: "Field" })).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "residual" }));
+    await waitFor(() => {
+      const call = plotCalls.filter((c) => c.ariaLabel === "residual spectrogram").at(-1);
+      expect(call).toBeDefined();
+      const trace = call!.data[0] as Record<string, unknown>;
+      expect(trace.colorscale).toBe("RdBu");
+      expect(trace.zmid).toBe(0);
+    });
+  });
+
+  it("says what it did to the array rather than implying full resolution", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() =>
+      expect(screen.getByText(/Block-averaged 8× in wavelength from 6 × 32/)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("lineout scrubber", () => {
+  it("renders measured, fitted and residual traces", async () => {
+    stubApi();
+    renderDetail();
+
+    await waitFor(() => {
+      const call = plotCalls.find((c) => c.ariaLabel === "Measured versus fitted spectrum");
+      expect(call).toBeDefined();
+      const names = (call!.data as Array<Record<string, unknown>>).map((trace) => trace.name);
+      expect(names).toEqual(["Data", "Fit", "Residual"]);
+    });
+  });
+
+  it("moving the scrubber refetches that lineout and puts it in the URL", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByLabelText("Lineout index")).toBeInTheDocument());
+
+    // Range inputs cannot be typed into; a change event is how they move.
+    fireEvent.change(screen.getByLabelText("Lineout index"), { target: { value: "3" } });
+
+    await waitFor(() => expect(requested.some((url) => url.includes("index=3"))).toBe(true));
+  });
+
+  it("reads the starting lineout from the URL so a link can point at one", async () => {
+    stubApi();
+    renderDetail("/runs/run-abc?lineout=4");
+    await waitFor(() => expect(requested.some((url) => url.includes("index=4"))).toBe(true));
+    expect(screen.getByText("Lineout 5 of 6")).toBeInTheDocument();
+  });
+
+  it("explains that IRF components are unavailable rather than omitting them", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() =>
+      expect(screen.getByText(/IRF and noise components are not available/)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("profiles panel", () => {
+  it("groups series by parameter and plots against the lineout axis", async () => {
+    stubApi();
+    renderDetail();
+
+    await waitFor(() => {
+      const te = plotCalls.find((c) => c.ariaLabel === "Te versus lineout");
+      expect(te).toBeDefined();
+      const trace = (te!.data as Array<Record<string, unknown>>)[0]!;
+      // Species becomes the trace name so two species overlay on one plot.
+      expect(trace.name).toBe("electron");
+      expect(trace.x).toEqual(profiles().x);
+    });
+  });
+
+  it("says when a run computed no uncertainties instead of showing bare lines", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByText(/did not compute uncertainties/)).toBeInTheDocument());
+  });
+});
+
+describe("loss panel", () => {
+  it("prefers a per-step metric over a single-point summary", async () => {
+    // There is no metric called "loss"; requesting one would 404 on every run.
+    stubApi();
+    renderDetail();
+
+    await waitFor(() => expect(requested.some((url) => url.includes("/metrics/"))).toBe(true));
+    const metricRequest = requested.find((url) => url.includes("/metrics/"))!;
+    expect(decodeURIComponent(metricRequest)).toContain("/metrics/epoch loss");
+    expect(metricRequest).not.toContain("/metrics/loss?");
+  });
+
+  it("encodes the space in the metric name", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(requested.some((url) => url.includes("epoch%20loss"))).toBe(true));
+  });
+
+  it("offers the run's other loss metrics but not unrelated ones", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByLabelText(/Metric/i)).toBeInTheDocument());
+
+    const options = within(screen.getByRole("combobox", { name: /Metric/i })).getAllByRole("option");
+    expect(options.map((option) => option.textContent)).toEqual(["epoch loss", "overall loss"]);
+  });
+
+  it("says so when a run logged no loss metric at all", async () => {
+    stubApi({ detail: runDetail({ metrics: [{ key: "fit_time", value: 42 }] }) });
+    renderDetail();
+    await waitFor(() => expect(screen.getByText("This run logged no loss metrics.")).toBeInTheDocument());
+  });
+});
+
+describe("config panel", () => {
+  it("shows the merged tree rebuilt from logged params", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByText("shotnum")).toBeInTheDocument());
+    // The tree renders the value next to its key, distinct from the header fact.
+    const tree = screen.getByText("shotnum").closest("li");
+    expect(tree).not.toBeNull();
+    expect(within(tree as HTMLElement).getByText("101675")).toBeInTheDocument();
+  });
+
+  it("disables the diff for an app-queued run that logged one merged config", async () => {
+    stubApi();
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "diff" })).toBeDisabled());
+    expect(
+      screen.getByText(/logged a single merged config.yaml, so there are no defaults to diff/),
+    ).toBeInTheDocument();
+  });
+
+  it("diffs inputs against defaults for a NERSC-queued run", async () => {
+    stubApi({
+      detail: runDetail({
+        artifacts: [
+          { path: "defaults.yaml", is_dir: false, size: 200 },
+          { path: "inputs.yaml", is_dir: false, size: 80 },
+        ],
+      }),
+      yaml: {
+        "defaults.yaml": "data:\n  shotnum: 1\n  lineouts:\n    start: 800\nother:\n  refit: false\n",
+        "inputs.yaml": "data:\n  shotnum: 101675\n  lineouts:\n    start: 800\n",
+      },
+    });
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "diff" })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: "diff" }));
+
+    await waitFor(() => expect(screen.getByText("data.shotnum")).toBeInTheDocument());
+    // Changed-only by default: that's the "what did I vary?" question.
+    expect(screen.queryByText("data.lineouts.start")).toBeNull();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /Changed keys only/ }));
+    await waitFor(() => expect(screen.getByText("data.lineouts.start")).toBeInTheDocument());
+  });
+});
+
+describe("angular and pre-contract runs", () => {
+  it("shows the gallery with the backend's reason, not an error", async () => {
+    stubApi({
+      detail: runDetail({ spectype: "angular_full" }),
+      probe: angularAvailability(),
+    });
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByText("Interactive views unavailable")).toBeInTheDocument());
+    expect(screen.getByText(/angularly-resolved run/)).toBeInTheDocument();
+    // Not an error: this is a scope decision, not a failure.
+    expect(screen.queryByRole("alert")).toBeNull();
+    // And the page is never blank.
+    expect(screen.getByText("Plots and files")).toBeInTheDocument();
+    expect(screen.getByAltText("plots/fit_and_data.png")).toBeInTheDocument();
+  });
+
+  it("labels an angular run in the header", async () => {
+    stubApi({ detail: runDetail({ spectype: "angular_full" }), probe: angularAvailability() });
+    renderDetail();
+    await waitFor(() => expect(screen.getByText("angular")).toBeInTheDocument());
+  });
+
+  it("does not request slicing endpoints for an unsupported run", async () => {
+    stubApi({ probe: angularAvailability() });
+    renderDetail();
+    await waitFor(() => expect(screen.getByText("Interactive views unavailable")).toBeInTheDocument());
+    expect(requested.some((url) => url.includes("/spectrogram"))).toBe(false);
+    expect(requested.some((url) => url.includes("/lineout"))).toBe(false);
+  });
+
+  it("shows the gallery for a pre-contract run with its own message", async () => {
+    stubApi({
+      probe: availability({
+        kind: "unknown",
+        supported: false,
+        reason: "dataset_missing",
+        message: "This run has no readable fit/data datasets, which is expected for older runs.",
+        spectra: [],
+        profiles_available: false,
+      }),
+    });
+    renderDetail();
+    await waitFor(() => expect(screen.getByText(/no readable fit\/data datasets/)).toBeInTheDocument());
+  });
+});
+
+describe("artifact gallery", () => {
+  it("serves images through the API rather than S3", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() =>
+      expect(screen.getByAltText("plots/fit_and_data.png")).toHaveAttribute(
+        "src",
+        "/api/runs/run-abc/artifacts/plots/fit_and_data.png",
+      ),
+    );
+  });
+
+  it("lists non-image artifacts separately", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "csv/learned_parameters.csv" })).toBeInTheDocument(),
+    );
+  });
+
+  it("skips directory entries", async () => {
+    stubApi();
+    renderDetail();
+    await waitFor(() => expect(screen.getByText("Plots and files")).toBeInTheDocument());
+    expect(screen.queryByRole("link", { name: "binary" })).toBeNull();
+  });
+});
+
+describe("failures", () => {
+  it("surfaces an error with a retry when the run cannot be read", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 404, json: async () => ({ detail: "run not found" }) })),
+    );
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByText("run not found")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("a failed loss history does not take down the rest of the page", async () => {
+    stubApi({ failMetric: true });
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByText("shot-101675-scan")).toBeInTheDocument());
+    expect(screen.getByText("Plots and files")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/config.test.ts
+++ b/frontend/src/__tests__/config.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { configSources, diffConfigs, displayValue, flattenConfig } from "../lib/config";
+
+describe("flattenConfig", () => {
+  it("uses dotted keys, matching how tsadar logs params", () => {
+    expect(flattenConfig({ data: { shotnum: 101675, lineouts: { start: 800 } } })).toEqual({
+      "data.shotnum": 101675,
+      "data.lineouts.start": 800,
+    });
+  });
+
+  it("treats arrays as leaves rather than indexing into them", () => {
+    // other.lamrangE is [400, 700] in the real config; splitting it into
+    // lamrangE.0 / lamrangE.1 would make the diff unreadable.
+    expect(flattenConfig({ other: { lamrangE: [400, 700] } })).toEqual({
+      "other.lamrangE": [400, 700],
+    });
+  });
+
+  it("keeps nulls as leaves", () => {
+    expect(flattenConfig({ a: { b: null } })).toEqual({ "a.b": null });
+  });
+});
+
+describe("diffConfigs", () => {
+  const defaults = { data: { shotnum: 1, lineouts: { start: 800 } }, other: { refit: false } };
+  const inputs = { data: { shotnum: 101675, lineouts: { start: 800 } }, extra: { thing: 2 } };
+
+  it("classifies changed, same, added and removed keys", () => {
+    const byKey = new Map(diffConfigs(defaults, inputs).map((row) => [row.key, row]));
+
+    expect(byKey.get("data.shotnum")?.status).toBe("changed");
+    expect(byKey.get("data.lineouts.start")?.status).toBe("same");
+    expect(byKey.get("extra.thing")?.status).toBe("added");
+    expect(byKey.get("other.refit")?.status).toBe("removed");
+  });
+
+  it("carries both sides so the table can show them", () => {
+    const row = diffConfigs(defaults, inputs).find((entry) => entry.key === "data.shotnum")!;
+    expect(row.base).toBe(1);
+    expect(row.override).toBe(101675);
+  });
+
+  it("compares structurally, so an equal array is not a change", () => {
+    const rows = diffConfigs({ a: [1, 2] }, { a: [1, 2] });
+    expect(rows[0]?.status).toBe("same");
+  });
+
+  it("is sorted by key so the table order is stable", () => {
+    const keys = diffConfigs(defaults, inputs).map((row) => row.key);
+    expect(keys).toEqual([...keys].sort());
+  });
+});
+
+describe("displayValue", () => {
+  it("distinguishes null from absent", () => {
+    expect(displayValue(null)).toBe("null");
+    expect(displayValue(undefined)).toBe("—");
+  });
+
+  it("renders booleans and numbers plainly and objects as JSON", () => {
+    expect(displayValue(false)).toBe("false");
+    expect(displayValue(5.0)).toBe("5");
+    expect(displayValue([400, 700])).toBe("[400,700]");
+  });
+});
+
+describe("configSources", () => {
+  it("is diffable only when both defaults and inputs are present", () => {
+    // NERSC-queued: two files, so "what did this run change?" is answerable.
+    expect(configSources(["defaults.yaml", "inputs.yaml"]).diffable).toBe(true);
+    // App-queued: one merged file, nothing to diff against.
+    expect(configSources(["config.yaml"]).diffable).toBe(false);
+    expect(configSources(["defaults.yaml"]).diffable).toBe(false);
+  });
+
+  it("reports which config artifacts exist", () => {
+    const sources = configSources(["config.yaml", "plots/a.png"]);
+    expect(sources.hasMerged).toBe(true);
+    expect(sources.hasDefaults).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/fixtures.ts
+++ b/frontend/src/__tests__/fixtures.ts
@@ -1,0 +1,141 @@
+/** Response fixtures shaped like the real API. */
+
+export function runDetail(overrides: Record<string, unknown> = {}) {
+  return {
+    run_id: "run-abc",
+    run_name: "shot-101675-scan",
+    experiment_id: "1",
+    experiment_name: "inverse-thomson-scattering",
+    status: "FINISHED",
+    stage: "completed",
+    shot: "101675",
+    spectype: "temporal",
+    final_loss: 12.5,
+    loss_key: "overall loss",
+    start_time: 1_700_000_000_000,
+    end_time: 1_700_000_123_000,
+    duration_s: 123,
+    user: "archis",
+    artifact_uri: "s3://public-ergodic-continuum/1/run-abc/artifacts",
+    mlflow_run_url: "https://continuum.ergodic.io/experiments/#/experiments/1/runs/run-abc",
+    config: { data: { shotnum: 101675, lineouts: { start: 800, end: 940 } } },
+    config_flat: { "data.shotnum": "101675" },
+    config_unflatten_error: null,
+    tags: {},
+    metrics: [
+      { key: "overall loss", value: 12.5 },
+      { key: "epoch loss", value: 13.1 },
+      { key: "fit_time", value: 42 },
+    ],
+    artifacts: [
+      { path: "binary", is_dir: true, size: null },
+      { path: "binary/ele_fit_and_data.nc", is_dir: false, size: 4096 },
+      { path: "plots/fit_and_data.png", is_dir: false, size: 2048 },
+      { path: "csv/learned_parameters.csv", is_dir: false, size: 512 },
+      // App-queued runs log a single merged config, so there is nothing to diff.
+      { path: "config.yaml", is_dir: false, size: 900 },
+    ],
+    manifest: null,
+    ...overrides,
+  };
+}
+
+export function availability(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "one_d",
+    supported: true,
+    reason: null,
+    message: null,
+    spectra: [
+      {
+        which: "ele",
+        path: "binary/ele_fit_and_data.nc",
+        x_label: "Time (ps)",
+        y_label: "Wavelength",
+        lineout_count: 6,
+        wavelength_count: 32,
+        fields: ["data", "fit", "residual"],
+      },
+    ],
+    profiles_available: true,
+    sigmas_available: false,
+    unavailable_fields: { irf: "IRF and noise components are not written to the netCDF datasets" },
+    ...overrides,
+  };
+}
+
+export const angularAvailability = () =>
+  availability({
+    kind: "angular",
+    supported: false,
+    reason: "angular_not_supported",
+    message:
+      "This is an angularly-resolved run. Interactive spectrogram, lineout and profile views are limited to 1D (time- or space-resolved) Thomson; the plot gallery for this run is still available.",
+    spectra: [],
+    profiles_available: false,
+  });
+
+export function spectrogram(overrides: Record<string, unknown> = {}) {
+  return {
+    which: "ele",
+    field: "data",
+    x_label: "Time (ps)",
+    y_label: "Wavelength",
+    x: [-100, -60, -20, 20, 60, 100],
+    y: [520, 525, 530, 535],
+    values: [
+      [1, 2, 3, 4, 5, 6],
+      [2, 3, 4, 5, 6, 7],
+      [3, 4, 5, 6, 7, 8],
+      [4, 5, 6, 7, 8, 9],
+    ],
+    full_shape: [6, 32],
+    returned_shape: [6, 4],
+    downsample_factors: { x: 1, wavelength: 8 },
+    downsample_method: "mean",
+    ...overrides,
+  };
+}
+
+export function lineout(overrides: Record<string, unknown> = {}) {
+  return {
+    which: "ele",
+    index: 0,
+    lineout_count: 6,
+    x_label: "Time (ps)",
+    x_value: -100,
+    y_label: "Wavelength",
+    wavelength: [520, 525, 530, 535],
+    data: [1, 2, 3, 4],
+    fit: [0.9, 1.9, 2.9, 3.9],
+    residual: [0.1, 0.1, 0.1, 0.1],
+    components: {},
+    components_unavailable: "IRF and noise components are not written to the netCDF datasets",
+    ...overrides,
+  };
+}
+
+export function profiles(overrides: Record<string, unknown> = {}) {
+  return {
+    x_label: "Time (ps)",
+    x: [-100, -60, -20, 20, 60, 100],
+    lineout_pixels: [800, 801, 802, 803, 804, 805],
+    series: [
+      { name: "Te_electron", values: [0.4, 0.5, 0.6, 0.7, 0.8, 0.9], sigma: null },
+      { name: "ne_electron", values: [0.1, 0.15, 0.2, 0.25, 0.3, 0.35], sigma: null },
+    ],
+    sigmas_available: false,
+    ...overrides,
+  };
+}
+
+export function metricHistory(key = "epoch loss") {
+  return {
+    key,
+    points: [
+      { step: 0, value: 20, timestamp: 1 },
+      { step: 1, value: 15, timestamp: 2 },
+      { step: 2, value: 12.5, timestamp: 3 },
+    ],
+  };
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,20 @@ export type RunPage = Json<"/api/runs", "get">;
 export type RunSummary = RunPage["runs"][number];
 export type RunDetail = Json<"/api/runs/{run_id}", "get">;
 export type Health = Json<"/api/health", "get">;
+export type ArtifactEntry = RunDetail["artifacts"][number];
+export type MetricHistory = Json<"/api/runs/{run_id}/metrics/{key}", "get">;
+
+export type DatasetAvailability = Json<"/api/runs/{run_id}/datasets", "get">;
+export type SpectrumInfo = DatasetAvailability["spectra"][number];
+export type Spectrogram = Json<"/api/runs/{run_id}/spectrogram", "get">;
+export type Lineout = Json<"/api/runs/{run_id}/lineout", "get">;
+export type Profiles = Json<"/api/runs/{run_id}/profiles", "get">;
+export type ProfileSeries = Profiles["series"][number];
+
+/** Spectrogram fields the backend can serve. `residual` is derived as data - fit;
+ *  `irf` is deliberately absent because it is not in the netCDF datasets. */
+export const SPECTROGRAM_FIELDS = ["data", "fit", "residual"] as const;
+export type SpectrogramField = (typeof SPECTROGRAM_FIELDS)[number];
 
 /** Sort keys the backend accepts. Duration is deliberately absent: it is computed
  *  from timestamps and MLflow cannot order by it, so offering it would 400. */
@@ -107,6 +121,17 @@ export function runQueryParams(query: RunQuery): URLSearchParams {
   return params;
 }
 
+/** URL for an artifact, served through the API so the browser never touches S3.
+ *
+ *  Each path segment is encoded separately: the slashes are real path structure
+ *  (`plots/fit_and_data.png`), so encoding the whole thing would break it. */
+export function artifactUrl(runId: string, artifactPath: string): string {
+  const segments = artifactPath.split("/").map(encodeURIComponent).join("/");
+  return `/api/runs/${encodeURIComponent(runId)}/artifacts/${segments}`;
+}
+
+const runPath = (runId: string, suffix = "") => `/api/runs/${encodeURIComponent(runId)}${suffix}`;
+
 export const api = {
   health: (signal?: AbortSignal) => request<Health>("/api/health", undefined, signal),
 
@@ -119,5 +144,39 @@ export const api = {
     request<RunPage>("/api/runs", runQueryParams(query), signal),
 
   run: (runId: string, signal?: AbortSignal) =>
-    request<RunDetail>(`/api/runs/${encodeURIComponent(runId)}`, undefined, signal),
+    request<RunDetail>(runPath(runId), undefined, signal),
+
+  /** Metric keys contain spaces ("overall loss"), so they must be encoded. */
+  metricHistory: (runId: string, key: string, signal?: AbortSignal) =>
+    request<MetricHistory>(runPath(runId, `/metrics/${encodeURIComponent(key)}`), undefined, signal),
+
+  datasets: (runId: string, signal?: AbortSignal) =>
+    request<DatasetAvailability>(runPath(runId, "/datasets"), undefined, signal),
+
+  spectrogram: (
+    runId: string,
+    options: { which: string; field: SpectrogramField; maxPx?: number },
+    signal?: AbortSignal,
+  ) => {
+    const params = new URLSearchParams({ which: options.which, field: options.field });
+    if (options.maxPx) params.set("max_px", String(options.maxPx));
+    return request<Spectrogram>(runPath(runId, "/spectrogram"), params, signal);
+  },
+
+  lineout: (runId: string, options: { which: string; index: number }, signal?: AbortSignal) =>
+    request<Lineout>(
+      runPath(runId, "/lineout"),
+      new URLSearchParams({ which: options.which, index: String(options.index) }),
+      signal,
+    ),
+
+  profiles: (runId: string, signal?: AbortSignal) =>
+    request<Profiles>(runPath(runId, "/profiles"), undefined, signal),
+
+  /** Fetch an artifact as text, for the YAML config files. */
+  artifactText: async (runId: string, artifactPath: string, signal?: AbortSignal) => {
+    const response = await fetch(artifactUrl(runId, artifactPath), { signal });
+    if (!response.ok) throw new ApiError(response.status, `could not fetch ${artifactPath}`);
+    return response.text();
+  },
 };

--- a/frontend/src/components/ArtifactGallery.tsx
+++ b/frontend/src/components/ArtifactGallery.tsx
@@ -1,0 +1,73 @@
+/**
+ * The PNG/CSV listing.
+ *
+ * Always shown, not only as a fallback: even a fully interactive run has images
+ * the slicing API cannot reproduce (the distribution-function contours, the
+ * error histogram, and the lineout plots that *do* include IRF and noise
+ * components). For angular and pre-contract runs it is the whole view, which is
+ * why the page must never be blank.
+ */
+
+import { artifactUrl, type ArtifactEntry } from "../api/client";
+
+const IMAGE_PATTERN = /\.(png|jpe?g|svg|gif)$/i;
+
+interface ArtifactGalleryProps {
+  runId: string;
+  artifacts: ArtifactEntry[];
+  /** Shown above the gallery when it is standing in for the interactive views. */
+  fallbackMessage?: string | null;
+}
+
+export function ArtifactGallery({ runId, artifacts, fallbackMessage }: ArtifactGalleryProps) {
+  const files = artifacts.filter((entry) => !entry.is_dir);
+  const images = files.filter((entry) => IMAGE_PATTERN.test(entry.path));
+  const others = files.filter((entry) => !IMAGE_PATTERN.test(entry.path));
+
+  return (
+    <section className="panel" aria-labelledby="gallery-heading">
+      <header className="panel__header">
+        <h2 id="gallery-heading">Plots and files</h2>
+        <span className="panel__meta">
+          {images.length} image{images.length === 1 ? "" : "s"}, {others.length} other
+        </span>
+      </header>
+
+      {fallbackMessage && (
+        <p className="panel__status panel__status--notice" role="status">
+          {fallbackMessage}
+        </p>
+      )}
+
+      {files.length === 0 && <p className="panel__status">This run logged no artifacts.</p>}
+
+      {images.length > 0 && (
+        <ul className="gallery">
+          {images.map((entry) => (
+            <li key={entry.path} className="gallery__item">
+              <a href={artifactUrl(runId, entry.path)} target="_blank" rel="noreferrer">
+                <img src={artifactUrl(runId, entry.path)} alt={entry.path} loading="lazy" />
+                <span className="gallery__caption">{entry.path}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {others.length > 0 && (
+        <ul className="filelist">
+          {others.map((entry) => (
+            <li key={entry.path}>
+              <a href={artifactUrl(runId, entry.path)} target="_blank" rel="noreferrer">
+                {entry.path}
+              </a>
+              {entry.size !== null && entry.size !== undefined && (
+                <span className="filelist__size">{Math.max(1, Math.round(entry.size / 1024))} KB</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -1,0 +1,184 @@
+/**
+ * The run's config, plus a diff when the run recorded one.
+ *
+ * The merged tree always comes from the run detail response (rebuilt from logged
+ * params) and is always shown. The diff is extra: NERSC-queued runs log
+ * `defaults.yaml` and `inputs.yaml` separately, so those can be diffed to answer
+ * "what did this run actually change?". App-queued runs log a single merged
+ * `config.yaml`, so there is nothing to diff and the panel says so rather than
+ * showing an empty table.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { parse as parseYaml } from "yaml";
+
+import { api, type RunDetail } from "../api/client";
+import { CONFIG_ARTIFACTS, configSources, diffConfigs, displayValue, type ConfigDiffRow } from "../lib/config";
+
+interface ConfigPanelProps {
+  runId: string;
+  run: RunDetail;
+}
+
+function ConfigTree({ value, depth = 0 }: { value: unknown; depth?: number }) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return <span className="config__value">{displayValue(value)}</span>;
+  }
+
+  return (
+    <ul className="config__tree" style={{ marginLeft: depth === 0 ? 0 : "0.9rem" }}>
+      {Object.entries(value as Record<string, unknown>).map(([key, child]) => {
+        const isBranch = child !== null && typeof child === "object" && !Array.isArray(child);
+        return (
+          <li key={key} className="config__node">
+            {isBranch ? (
+              <details open={depth < 1}>
+                <summary className="config__key">{key}</summary>
+                <ConfigTree value={child} depth={depth + 1} />
+              </details>
+            ) : (
+              <>
+                <span className="config__key">{key}</span>
+                <ConfigTree value={child} depth={depth + 1} />
+              </>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function ConfigPanel({ runId, run }: ConfigPanelProps) {
+  const sources = useMemo(
+    () => configSources(run.artifacts.filter((entry) => !entry.is_dir).map((entry) => entry.path)),
+    [run.artifacts],
+  );
+
+  const [diff, setDiff] = useState<ConfigDiffRow[] | null>(null);
+  const [diffError, setDiffError] = useState<string | null>(null);
+  const [changedOnly, setChangedOnly] = useState(true);
+  const [view, setView] = useState<"tree" | "diff">("tree");
+
+  useEffect(() => {
+    if (!sources.diffable) return;
+    const controller = new AbortController();
+
+    Promise.all([
+      api.artifactText(runId, CONFIG_ARTIFACTS.defaults, controller.signal),
+      api.artifactText(runId, CONFIG_ARTIFACTS.inputs, controller.signal),
+    ])
+      .then(([defaultsText, inputsText]) =>
+        setDiff(diffConfigs(parseYaml(defaultsText), parseYaml(inputsText))),
+      )
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setDiffError(cause instanceof Error ? cause.message : "Could not build the config diff.");
+      });
+
+    return () => controller.abort();
+  }, [runId, sources.diffable]);
+
+  const rows = diff?.filter((row) => (changedOnly ? row.status !== "same" : true)) ?? [];
+  const changedCount = diff?.filter((row) => row.status !== "same").length ?? 0;
+
+  return (
+    <section className="panel" aria-labelledby="config-heading">
+      <header className="panel__header">
+        <h2 id="config-heading">Configuration</h2>
+        <div className="panel__controls">
+          <div className="segmented" role="group" aria-label="Config view">
+            <button
+              type="button"
+              className={`segmented__option${view === "tree" ? " segmented__option--active" : ""}`}
+              aria-pressed={view === "tree"}
+              onClick={() => setView("tree")}
+            >
+              tree
+            </button>
+            <button
+              type="button"
+              className={`segmented__option${view === "diff" ? " segmented__option--active" : ""}`}
+              aria-pressed={view === "diff"}
+              onClick={() => setView("diff")}
+              disabled={!sources.diffable}
+              title={
+                sources.diffable
+                  ? undefined
+                  : "This run logged a single merged config.yaml, so there is nothing to diff against."
+              }
+            >
+              diff
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {run.config_unflatten_error && (
+        <p className="panel__status panel__status--error" role="alert">
+          The config tree could not be rebuilt from this run's logged parameters (
+          {run.config_unflatten_error}). The flat parameter list is still available on the MLflow run
+          page.
+        </p>
+      )}
+
+      {view === "tree" && <ConfigTree value={run.config} />}
+
+      {view === "diff" && (
+        <>
+          {diffError && (
+            <p className="panel__status panel__status--error" role="alert">
+              {diffError}
+            </p>
+          )}
+          {!diff && !diffError && <p className="panel__status">Loading config diff…</p>}
+          {diff && (
+            <>
+              <label className="control control--inline">
+                <input
+                  type="checkbox"
+                  checked={changedOnly}
+                  onChange={(event) => setChangedOnly(event.target.checked)}
+                />
+                <span>Changed keys only ({changedCount})</span>
+              </label>
+
+              <table className="difftable">
+                <thead>
+                  <tr>
+                    <th scope="col">Key</th>
+                    <th scope="col">defaults.yaml</th>
+                    <th scope="col">inputs.yaml</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr key={row.key} className={`difftable__row difftable__row--${row.status}`}>
+                      <td>{row.key}</td>
+                      <td>{displayValue(row.base)}</td>
+                      <td>{displayValue(row.override)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              {rows.length === 0 && (
+                <p className="panel__status">
+                  {changedOnly ? "This run changed nothing from the defaults." : "No config keys."}
+                </p>
+              )}
+            </>
+          )}
+        </>
+      )}
+
+      {!sources.diffable && view === "tree" && (
+        <p className="panel__note">
+          {sources.hasMerged
+            ? "This run logged a single merged config.yaml, so there are no defaults to diff against."
+            : "This run logged no config YAML artifacts; the tree above is rebuilt from its logged parameters."}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/LineoutPanel.tsx
+++ b/frontend/src/components/LineoutPanel.tsx
@@ -6,7 +6,7 @@
  * `best/` and `worst/` PNGs with something you can step through.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { ApiError, api, type Lineout, type SpectrumInfo } from "../api/client";
 import { axisLabel } from "../lib/format";
@@ -48,32 +48,44 @@ export function LineoutPanel({ runId, spectrum, which, index, onIndexChange }: L
     return () => controller.abort();
   }, [runId, which, clamped]);
 
-  const traces = lineout
-    ? [
-        { type: "scatter", mode: "lines", name: "Data", x: lineout.wavelength, y: lineout.data },
-        { type: "scatter", mode: "lines", name: "Fit", x: lineout.wavelength, y: lineout.fit },
-        {
-          type: "scatter",
-          mode: "lines",
-          name: "Residual",
-          x: lineout.wavelength,
-          y: lineout.residual,
-          yaxis: "y2",
-          line: { width: 1, dash: "dot" },
-        },
-      ]
-    : [];
+  // Memoized so `Plot` only re-plots when the fetched lineout actually changes.
+  // Dragging the scrubber re-renders this component far faster than the request
+  // it fires can return, and each of those renders would otherwise rebuild the
+  // traces by identity and trigger a redraw of the previous lineout.
+  const traces = useMemo(
+    () =>
+      lineout
+        ? [
+            { type: "scatter", mode: "lines", name: "Data", x: lineout.wavelength, y: lineout.data },
+            { type: "scatter", mode: "lines", name: "Fit", x: lineout.wavelength, y: lineout.fit },
+            {
+              type: "scatter",
+              mode: "lines",
+              name: "Residual",
+              x: lineout.wavelength,
+              y: lineout.residual,
+              yaxis: "y2",
+              line: { width: 1, dash: "dot" },
+            },
+          ]
+        : [],
+    [lineout],
+  );
 
-  const layout = lineout
-    ? {
-        xaxis: { title: axisLabel(lineout.y_label) },
-        yaxis: { title: "Amplitude (arb.)", domain: [0.32, 1] },
-        yaxis2: { title: "Residual", domain: [0, 0.24] },
-        showlegend: true,
-        legend: { orientation: "h", y: 1.12 },
-        margin: { t: 30, r: 20, b: 45, l: 60 },
-      }
-    : {};
+  const layout = useMemo(
+    () =>
+      lineout
+        ? {
+            xaxis: { title: axisLabel(lineout.y_label) },
+            yaxis: { title: "Amplitude (arb.)", domain: [0.32, 1] },
+            yaxis2: { title: "Residual", domain: [0, 0.24] },
+            showlegend: true,
+            legend: { orientation: "h", y: 1.12 },
+            margin: { t: 30, r: 20, b: 45, l: 60 },
+          }
+        : {},
+    [lineout],
+  );
 
   return (
     <section className="panel" aria-labelledby="lineout-heading">

--- a/frontend/src/components/LineoutPanel.tsx
+++ b/frontend/src/components/LineoutPanel.tsx
@@ -1,0 +1,126 @@
+/**
+ * Measured vs fitted spectrum at one lineout, with a scrubber.
+ *
+ * Linked to the spectrogram: clicking a column there moves this, and moving the
+ * slider moves the marker there. This replaces the pre-rendered `lineouts/`,
+ * `best/` and `worst/` PNGs with something you can step through.
+ */
+
+import { useEffect, useState } from "react";
+
+import { ApiError, api, type Lineout, type SpectrumInfo } from "../api/client";
+import { axisLabel } from "../lib/format";
+import { Plot } from "./Plot";
+
+interface LineoutPanelProps {
+  runId: string;
+  spectrum: SpectrumInfo;
+  which: string;
+  index: number;
+  onIndexChange: (index: number) => void;
+}
+
+export function LineoutPanel({ runId, spectrum, which, index, onIndexChange }: LineoutPanelProps) {
+  const [lineout, setLineout] = useState<Lineout | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const maxIndex = Math.max(0, spectrum.lineout_count - 1);
+  const clamped = Math.min(Math.max(index, 0), maxIndex);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    api
+      .lineout(runId, { which, index: clamped }, controller.signal)
+      .then(setLineout)
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setLineout(null);
+        setError(cause instanceof ApiError ? cause.message : "Could not load the lineout.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [runId, which, clamped]);
+
+  const traces = lineout
+    ? [
+        { type: "scatter", mode: "lines", name: "Data", x: lineout.wavelength, y: lineout.data },
+        { type: "scatter", mode: "lines", name: "Fit", x: lineout.wavelength, y: lineout.fit },
+        {
+          type: "scatter",
+          mode: "lines",
+          name: "Residual",
+          x: lineout.wavelength,
+          y: lineout.residual,
+          yaxis: "y2",
+          line: { width: 1, dash: "dot" },
+        },
+      ]
+    : [];
+
+  const layout = lineout
+    ? {
+        xaxis: { title: axisLabel(lineout.y_label) },
+        yaxis: { title: "Amplitude (arb.)", domain: [0.32, 1] },
+        yaxis2: { title: "Residual", domain: [0, 0.24] },
+        showlegend: true,
+        legend: { orientation: "h", y: 1.12 },
+        margin: { t: 30, r: 20, b: 45, l: 60 },
+      }
+    : {};
+
+  return (
+    <section className="panel" aria-labelledby="lineout-heading">
+      <header className="panel__header">
+        <h2 id="lineout-heading">Lineout</h2>
+        <span className="panel__meta">
+          {lineout
+            ? `${axisLabel(lineout.x_label)} = ${lineout.x_value.toPrecision(4)}`
+            : `index ${clamped}`}
+        </span>
+      </header>
+
+      <label className="scrubber">
+        <span className="scrubber__label">
+          Lineout {clamped + 1} of {spectrum.lineout_count}
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={maxIndex}
+          value={clamped}
+          aria-label="Lineout index"
+          onChange={(event) => onIndexChange(Number(event.target.value))}
+        />
+      </label>
+
+      {loading && <p className="panel__status">Loading lineout…</p>}
+      {error && (
+        <p className="panel__status panel__status--error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {lineout && !error && (
+        <>
+          <Plot data={traces} layout={layout} height={360} ariaLabel="Measured versus fitted spectrum" />
+          {lineout.components_unavailable && (
+            // Stated rather than silently omitted: someone comparing this with
+            // the old PNGs will notice the components are missing and deserve to
+            // know it is a data limitation, not a rendering bug.
+            <p className="panel__note">
+              IRF and noise components are not available for interactive plots — they are not stored
+              in the netCDF datasets, only in the pre-rendered lineout images below.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/LossPanel.tsx
+++ b/frontend/src/components/LossPanel.tsx
@@ -1,0 +1,123 @@
+/**
+ * Loss history.
+ *
+ * There is no metric called `loss`. tsadar logs `overall loss`, `min loss`,
+ * `epoch loss` and `batch loss` -- names with **spaces** in them -- so this picks
+ * from what the run actually reported rather than requesting a fixed key that
+ * would 404 on every run.
+ *
+ * `epoch loss` is the one with a real history worth plotting (it is logged per
+ * step); `overall loss` is typically a single summary point. So the panel prefers
+ * whichever key has the most points and lets you switch.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ApiError, api, type MetricHistory, type RunDetail } from "../api/client";
+import { Plot } from "./Plot";
+
+/** Metric keys that are loss curves, in rough order of usefulness as a series. */
+const LOSS_KEY_PATTERN = /loss/i;
+
+export function lossKeys(run: RunDetail): string[] {
+  const keys = run.metrics.map((metric) => metric.key).filter((key) => LOSS_KEY_PATTERN.test(key));
+  // Per-step histories first: "epoch loss" and "batch loss" are logged with a
+  // step, while "overall loss" and "min loss" are summaries.
+  const rank = (key: string) => (key.includes("epoch") ? 0 : key.includes("batch") ? 1 : 2);
+  return keys.sort((left, right) => rank(left) - rank(right) || left.localeCompare(right));
+}
+
+interface LossPanelProps {
+  runId: string;
+  run: RunDetail;
+}
+
+export function LossPanel({ runId, run }: LossPanelProps) {
+  const keys = useMemo(() => lossKeys(run), [run]);
+  const [selected, setSelected] = useState<string | null>(keys[0] ?? null);
+  const [history, setHistory] = useState<MetricHistory | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selected) return;
+    const controller = new AbortController();
+    setError(null);
+
+    api
+      .metricHistory(runId, selected, controller.signal)
+      .then(setHistory)
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setHistory(null);
+        setError(cause instanceof ApiError ? cause.message : "Could not load the loss history.");
+      });
+
+    return () => controller.abort();
+  }, [runId, selected]);
+
+  if (keys.length === 0) {
+    return (
+      <section className="panel">
+        <h2>Loss</h2>
+        <p className="panel__status">This run logged no loss metrics.</p>
+      </section>
+    );
+  }
+
+  const traces = history
+    ? [
+        {
+          type: "scatter",
+          mode: history.points.length > 1 ? "lines+markers" : "markers",
+          x: history.points.map((point) => point.step),
+          y: history.points.map((point) => point.value),
+          name: history.key,
+        },
+      ]
+    : [];
+
+  return (
+    <section className="panel" aria-labelledby="loss-heading">
+      <header className="panel__header">
+        <h2 id="loss-heading">Loss</h2>
+        <label className="control">
+          <span>Metric</span>
+          <select value={selected ?? ""} onChange={(event) => setSelected(event.target.value)}>
+            {keys.map((key) => (
+              <option key={key} value={key}>
+                {key}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      {error && (
+        <p className="panel__status panel__status--error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {history && !error && (
+        <>
+          <Plot
+            data={traces}
+            layout={{
+              xaxis: { title: "Step" },
+              yaxis: { title: history.key },
+              margin: { t: 12, r: 16, b: 40, l: 62 },
+            }}
+            height={240}
+            ariaLabel={`${history.key} history`}
+          />
+          {history.points.length === 1 && (
+            <p className="panel__note">
+              A single point: <code>{history.key}</code> is logged once as a summary rather than per
+              step. Try <code>epoch loss</code> for a curve.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/Plot.tsx
+++ b/frontend/src/components/Plot.tsx
@@ -1,0 +1,61 @@
+/**
+ * The only place Plotly is touched.
+ *
+ * Two reasons this is a wrapper rather than direct calls in each panel:
+ *
+ * - Plotly is large even as the cartesian-only bundle, so it is loaded with a
+ *   dynamic import. The run browser never mounts a chart and should not pay for
+ *   one; this keeps it a separate chunk fetched on the detail page.
+ * - jsdom has no canvas or WebGL, so Plotly cannot render under test. Panels
+ *   mock this component and assert on the traces they pass in, which is the part
+ *   worth testing -- that the right arrays reach the chart.
+ */
+
+import { useEffect, useRef } from "react";
+
+export interface PlotProps {
+  data: unknown[];
+  layout?: Record<string, unknown>;
+  /** Fired with the clicked point's index along the trace. */
+  onPointClick?: (pointIndex: number) => void;
+  height?: number;
+  ariaLabel?: string;
+}
+
+const CONFIG = { displaylogo: false, responsive: true };
+
+export function Plot({ data, layout, onPointClick, height = 320, ariaLabel }: PlotProps) {
+  const container = useRef<HTMLDivElement>(null);
+  // Held in a ref so changing the handler does not force a re-plot.
+  const clickHandler = useRef(onPointClick);
+  clickHandler.current = onPointClick;
+
+  useEffect(() => {
+    const element = container.current;
+    if (!element) return;
+
+    let disposed = false;
+
+    void (async () => {
+      const Plotly = await import("plotly.js-cartesian-dist-min");
+      if (disposed) return;
+
+      const plot = await Plotly.react(element, data, { autosize: true, height, ...layout }, CONFIG);
+      if (disposed) return;
+
+      plot.removeAllListeners?.("plotly_click");
+      plot.on("plotly_click", (event) => {
+        const point = event.points[0];
+        const index = point?.pointIndex ?? point?.pointNumber;
+        if (index !== undefined) clickHandler.current?.(index);
+      });
+    })();
+
+    return () => {
+      disposed = true;
+      void import("plotly.js-cartesian-dist-min").then((Plotly) => Plotly.purge(element));
+    };
+  }, [data, layout, height]);
+
+  return <div ref={container} role="img" aria-label={ariaLabel} className="plot" />;
+}

--- a/frontend/src/components/Plot.tsx
+++ b/frontend/src/components/Plot.tsx
@@ -30,19 +30,31 @@ export function Plot({ data, layout, onPointClick, height = 320, ariaLabel }: Pl
   const clickHandler = useRef(onPointClick);
   clickHandler.current = onPointClick;
 
+  // Updates and teardown are separate effects on purpose. Purging on every
+  // `data`/`layout` change threw the graph away and rebuilt it from scratch --
+  // losing the user's zoom and pan, and forcing a full redraw where
+  // `Plotly.react` would have diffed. Worse, `Plotly.react` is async: a purge
+  // firing while one was in flight could leave an empty div behind.
+  //
+  // Declaration order matters. React runs cleanups in the order the effects
+  // were declared, so this one's cleanup marks the in-flight update stale
+  // *before* the teardown effect below purges, and nothing can render into an
+  // already-purged element.
   useEffect(() => {
     const element = container.current;
     if (!element) return;
 
-    let disposed = false;
+    let stale = false;
 
     void (async () => {
       const Plotly = await import("plotly.js-cartesian-dist-min");
-      if (disposed) return;
+      if (stale) return;
 
       const plot = await Plotly.react(element, data, { autosize: true, height, ...layout }, CONFIG);
-      if (disposed) return;
+      if (stale) return;
 
+      // `react` reuses the graph div, so a listener from the previous render is
+      // still attached and would fire twice.
       plot.removeAllListeners?.("plotly_click");
       plot.on("plotly_click", (event) => {
         const point = event.points[0];
@@ -52,10 +64,18 @@ export function Plot({ data, layout, onPointClick, height = 320, ariaLabel }: Pl
     })();
 
     return () => {
-      disposed = true;
-      void import("plotly.js-cartesian-dist-min").then((Plotly) => Plotly.purge(element));
+      stale = true;
     };
   }, [data, layout, height]);
+
+  useEffect(() => {
+    const element = container.current;
+    if (!element) return;
+
+    return () => {
+      void import("plotly.js-cartesian-dist-min").then((Plotly) => Plotly.purge(element));
+    };
+  }, []);
 
   return <div ref={container} role="img" aria-label={ariaLabel} className="plot" />;
 }

--- a/frontend/src/components/ProfilesPanel.tsx
+++ b/frontend/src/components/ProfilesPanel.tsx
@@ -1,0 +1,158 @@
+/**
+ * Fitted parameters versus lineout, with sigma error bars where the run has them.
+ *
+ * The series are whatever `learned_parameters.csv` holds -- `<param>_<species>`,
+ * so `Te_electron`, `ne_electron`, `Ti_ion`, flows and so on. They are not
+ * hardcoded, because which parameters were active varies per run; the panel
+ * groups them by parameter name so Te for two species overlays sensibly.
+ *
+ * `calc_sigmas` is off by default, so most runs have no error bars. That is
+ * normal and reported rather than treated as missing data.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ApiError, api, type Profiles } from "../api/client";
+import { axisLabel } from "../lib/format";
+import { Plot } from "./Plot";
+
+/** Split `Te_electron` into its parameter and species halves. */
+export function splitSeriesName(name: string): { parameter: string; species: string | null } {
+  const underscore = name.lastIndexOf("_");
+  if (underscore <= 0) return { parameter: name, species: null };
+  return { parameter: name.slice(0, underscore), species: name.slice(underscore + 1) };
+}
+
+/** Group series by parameter so the same quantity for different species shares a
+ *  plot, rather than producing one chart per column. */
+export function groupSeries(profiles: Profiles): Array<{ parameter: string; names: string[] }> {
+  const groups = new Map<string, string[]>();
+  for (const series of profiles.series) {
+    const { parameter } = splitSeriesName(series.name);
+    const existing = groups.get(parameter);
+    if (existing) existing.push(series.name);
+    else groups.set(parameter, [series.name]);
+  }
+  return [...groups.entries()].map(([parameter, names]) => ({ parameter, names }));
+}
+
+interface ProfilesPanelProps {
+  runId: string;
+  lineoutIndex: number;
+  onLineoutChange: (index: number) => void;
+}
+
+export function ProfilesPanel({ runId, lineoutIndex, onLineoutChange }: ProfilesPanelProps) {
+  const [profiles, setProfiles] = useState<Profiles | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    api
+      .profiles(runId, controller.signal)
+      .then(setProfiles)
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setProfiles(null);
+        setError(cause instanceof ApiError ? cause.message : "Could not load profiles.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [runId]);
+
+  const groups = useMemo(() => (profiles ? groupSeries(profiles) : []), [profiles]);
+
+  if (loading) {
+    return (
+      <section className="panel">
+        <h2>Profiles</h2>
+        <p className="panel__status">Loading profiles…</p>
+      </section>
+    );
+  }
+
+  if (error || !profiles) {
+    return (
+      <section className="panel">
+        <h2>Profiles</h2>
+        <p className="panel__status panel__status--error" role="alert">
+          {error ?? "No profiles available."}
+        </p>
+      </section>
+    );
+  }
+
+  const byName = new Map(profiles.series.map((series) => [series.name, series]));
+
+  return (
+    <section className="panel" aria-labelledby="profiles-heading">
+      <header className="panel__header">
+        <h2 id="profiles-heading">Fitted parameters</h2>
+        <span className="panel__meta">
+          {profiles.sigmas_available ? "with uncertainties" : "no uncertainties logged"}
+        </span>
+      </header>
+
+      <div className="profiles__grid">
+        {groups.map((group) => {
+          const traces = group.names.map((name) => {
+            const series = byName.get(name)!;
+            const { species } = splitSeriesName(name);
+            return {
+              type: "scatter",
+              mode: "lines+markers",
+              name: species ?? name,
+              x: profiles.x,
+              y: series.values,
+              error_y: series.sigma
+                ? { type: "data", array: series.sigma, visible: true, thickness: 1 }
+                : undefined,
+            };
+          });
+
+          return (
+            <div key={group.parameter} className="profiles__cell">
+              <Plot
+                data={traces}
+                layout={{
+                  title: { text: group.parameter, font: { size: 13 } },
+                  xaxis: { title: axisLabel(profiles.x_label) },
+                  margin: { t: 30, r: 12, b: 40, l: 52 },
+                  showlegend: group.names.length > 1,
+                  shapes: [
+                    {
+                      type: "line",
+                      x0: profiles.x[lineoutIndex] ?? null,
+                      x1: profiles.x[lineoutIndex] ?? null,
+                      yref: "paper",
+                      y0: 0,
+                      y1: 1,
+                      line: { color: "#ff7f0e", width: 1, dash: "dot" },
+                    },
+                  ],
+                }}
+                height={220}
+                ariaLabel={`${group.parameter} versus lineout`}
+                onPointClick={onLineoutChange}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {!profiles.sigmas_available && (
+        <p className="panel__note">
+          This run did not compute uncertainties (<code>calc_sigmas</code> is off by default), so the
+          profiles have no error bars.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/RunHeader.tsx
+++ b/frontend/src/components/RunHeader.tsx
@@ -1,0 +1,69 @@
+/**
+ * Run identity and status.
+ *
+ * Status and stage are shown as two separate badges on purpose: MLflow's
+ * lifecycle status and tsadar's own progress tag answer different questions, and
+ * a `FAILED` run whose stage is stuck at `minimizing` tells you where it died.
+ * Collapsing them into one badge would throw that away.
+ */
+
+import { Link } from "react-router-dom";
+
+import type { RunDetail } from "../api/client";
+import { formatDuration, formatLoss, formatTimestamp, isAngular, spectypeLabel } from "../lib/format";
+
+export function RunHeader({ run }: { run: RunDetail }) {
+  const facts: Array<[string, string]> = [
+    ["Shot", run.shot ?? "—"],
+    ["Experiment", run.experiment_name ?? run.experiment_id],
+    ["Type", spectypeLabel(run.spectype)],
+    ["Submitted by", run.user ?? "—"],
+    ["Started", formatTimestamp(run.start_time)],
+    ["Duration", formatDuration(run.duration_s)],
+    [run.loss_key ? `Final loss (${run.loss_key})` : "Final loss", formatLoss(run.final_loss)],
+  ];
+
+  return (
+    <header className="runheader">
+      <div className="runheader__title">
+        <Link to="/runs" className="runheader__back">
+          ← Runs
+        </Link>
+        <h1>{run.run_name ?? run.run_id}</h1>
+
+        <span className={`badge status--${(run.status ?? "unknown").toLowerCase()}`}>
+          {run.status ?? "unknown"}
+        </span>
+        {run.stage && (
+          <span className="badge badge--muted" title="tsadar's own progress tag">
+            {run.stage}
+          </span>
+        )}
+        {isAngular(run.spectype) && (
+          <span className="badge badge--muted" title="Interactive views are limited to 1D Thomson">
+            angular
+          </span>
+        )}
+
+        {run.mlflow_run_url && (
+          <a className="button runheader__mlflow" href={run.mlflow_run_url} target="_blank" rel="noreferrer">
+            Open in MLflow
+          </a>
+        )}
+      </div>
+
+      <dl className="runheader__facts">
+        {facts.map(([label, value]) => (
+          <div key={label} className="runheader__fact">
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <p className="runheader__runid">
+        <code>{run.run_id}</code>
+      </p>
+    </header>
+  );
+}

--- a/frontend/src/components/SpectrogramPanel.tsx
+++ b/frontend/src/components/SpectrogramPanel.tsx
@@ -1,0 +1,182 @@
+/**
+ * Interactive spectrogram with a data / fit / residual toggle.
+ *
+ * Clicking a column selects that lineout, which is what drives the linked
+ * spectrum panel -- the interactive replacement for the pre-rendered
+ * `lineouts/`, `best/` and `worst/` PNGs.
+ *
+ * There is no `irf` toggle: IRF and noise components are not in the netCDF
+ * datasets at all, only baked into those PNGs. The backend reports that through
+ * `unavailable_fields` and the gallery still has the images.
+ */
+
+import { useEffect, useState } from "react";
+
+import {
+  ApiError,
+  SPECTROGRAM_FIELDS,
+  api,
+  type SpectrogramField,
+  type Spectrogram,
+  type SpectrumInfo,
+} from "../api/client";
+import { axisLabel } from "../lib/format";
+import { Plot } from "./Plot";
+
+/** Say what the server did to the array, so the plot never silently implies
+ *  full resolution. Factors arrive as a plain map, hence the defaults. */
+export function describeDownsampling(spectrogram: Spectrogram): string {
+  const [lineouts, wavelengths] = spectrogram.full_shape;
+  const shape = `${lineouts} × ${wavelengths}`;
+
+  if (spectrogram.downsample_method === "none") return `Full resolution, ${shape}.`;
+
+  const wavelengthFactor = spectrogram.downsample_factors.wavelength ?? 1;
+  const lineoutFactor = spectrogram.downsample_factors.x ?? 1;
+
+  const parts = [`Block-averaged ${wavelengthFactor}× in wavelength`];
+  if (lineoutFactor > 1) {
+    parts.push(`and ${lineoutFactor}× along ${axisLabel(spectrogram.x_label)}`);
+  }
+  return `${parts.join(" ")} from ${shape}.`;
+}
+
+interface SpectrogramPanelProps {
+  runId: string;
+  spectra: SpectrumInfo[];
+  which: string;
+  onWhichChange: (which: string) => void;
+  lineoutIndex: number;
+  onLineoutChange: (index: number) => void;
+}
+
+export function SpectrogramPanel({
+  runId,
+  spectra,
+  which,
+  onWhichChange,
+  lineoutIndex,
+  onLineoutChange,
+}: SpectrogramPanelProps) {
+  const [field, setField] = useState<SpectrogramField>("data");
+  const [spectrogram, setSpectrogram] = useState<Spectrogram | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    api
+      .spectrogram(runId, { which, field }, controller.signal)
+      .then(setSpectrogram)
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setSpectrogram(null);
+        setError(cause instanceof ApiError ? cause.message : "Could not load the spectrogram.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [runId, which, field]);
+
+  const traces = spectrogram
+    ? [
+        {
+          type: "heatmap",
+          x: spectrogram.x,
+          y: spectrogram.y,
+          z: spectrogram.values,
+          // Residual is signed, so it reads far better on a diverging scale
+          // centred at zero than on a sequential one.
+          colorscale: field === "residual" ? "RdBu" : "Viridis",
+          zmid: field === "residual" ? 0 : undefined,
+          colorbar: { title: field },
+        },
+      ]
+    : [];
+
+  const layout = spectrogram
+    ? {
+        xaxis: { title: axisLabel(spectrogram.x_label) },
+        yaxis: { title: axisLabel(spectrogram.y_label) },
+        margin: { t: 10, r: 10, b: 45, l: 60 },
+        shapes: [
+          // The selected lineout, drawn as a vertical rule so the scrubber and
+          // the heatmap always agree about where you are.
+          {
+            type: "line",
+            x0: spectrogram.x[lineoutIndex] ?? null,
+            x1: spectrogram.x[lineoutIndex] ?? null,
+            yref: "paper",
+            y0: 0,
+            y1: 1,
+            line: { color: "#ff7f0e", width: 1.5, dash: "dot" },
+          },
+        ],
+      }
+    : {};
+
+  return (
+    <section className="panel" aria-labelledby="spectrogram-heading">
+      <header className="panel__header">
+        <h2 id="spectrogram-heading">Spectrogram</h2>
+
+        <div className="panel__controls">
+          {spectra.length > 1 && (
+            <label className="control">
+              <span>Spectrum</span>
+              <select value={which} onChange={(event) => onWhichChange(event.target.value)}>
+                {spectra.map((spectrum) => (
+                  <option key={spectrum.which} value={spectrum.which}>
+                    {spectrum.which === "ele" ? "electron (EPW)" : "ion (IAW)"}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <div className="segmented" role="group" aria-label="Field">
+            {SPECTROGRAM_FIELDS.map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                className={`segmented__option${candidate === field ? " segmented__option--active" : ""}`}
+                aria-pressed={candidate === field}
+                onClick={() => setField(candidate)}
+              >
+                {candidate}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {loading && <p className="panel__status">Loading spectrogram…</p>}
+      {error && (
+        <p className="panel__status panel__status--error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {spectrogram && !error && (
+        <>
+          <Plot
+            data={traces}
+            layout={layout}
+            height={340}
+            ariaLabel={`${field} spectrogram`}
+            onPointClick={(pointIndex) => onLineoutChange(pointIndex)}
+          />
+          <p className="panel__note">
+            {describeDownsampling(spectrogram)}
+            {field === "residual" && " Residual is derived as data − fit."}
+          </p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/SpectrogramPanel.tsx
+++ b/frontend/src/components/SpectrogramPanel.tsx
@@ -10,7 +10,7 @@
  * `unavailable_fields` and the gallery still has the images.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   ApiError,
@@ -83,42 +83,55 @@ export function SpectrogramPanel({
     return () => controller.abort();
   }, [runId, which, field]);
 
-  const traces = spectrogram
-    ? [
-        {
-          type: "heatmap",
-          x: spectrogram.x,
-          y: spectrogram.y,
-          z: spectrogram.values,
-          // Residual is signed, so it reads far better on a diverging scale
-          // centred at zero than on a sequential one.
-          colorscale: field === "residual" ? "RdBu" : "Viridis",
-          zmid: field === "residual" ? 0 : undefined,
-          colorbar: { title: field },
-        },
-      ]
-    : [];
+  // Memoized because `Plot` re-plots when these change by identity. Without it,
+  // dragging the lineout scrubber -- which re-renders this component on every
+  // pointer move -- would hand Plotly a brand new heatmap trace each time and
+  // redraw the whole array. The traces do not depend on `lineoutIndex` at all;
+  // only the marker in the layout does.
+  const traces = useMemo(
+    () =>
+      spectrogram
+        ? [
+            {
+              type: "heatmap",
+              x: spectrogram.x,
+              y: spectrogram.y,
+              z: spectrogram.values,
+              // Residual is signed, so it reads far better on a diverging scale
+              // centred at zero than on a sequential one.
+              colorscale: field === "residual" ? "RdBu" : "Viridis",
+              zmid: field === "residual" ? 0 : undefined,
+              colorbar: { title: field },
+            },
+          ]
+        : [],
+    [spectrogram, field],
+  );
 
-  const layout = spectrogram
-    ? {
-        xaxis: { title: axisLabel(spectrogram.x_label) },
-        yaxis: { title: axisLabel(spectrogram.y_label) },
-        margin: { t: 10, r: 10, b: 45, l: 60 },
-        shapes: [
-          // The selected lineout, drawn as a vertical rule so the scrubber and
-          // the heatmap always agree about where you are.
-          {
-            type: "line",
-            x0: spectrogram.x[lineoutIndex] ?? null,
-            x1: spectrogram.x[lineoutIndex] ?? null,
-            yref: "paper",
-            y0: 0,
-            y1: 1,
-            line: { color: "#ff7f0e", width: 1.5, dash: "dot" },
-          },
-        ],
-      }
-    : {};
+  const layout = useMemo(
+    () =>
+      spectrogram
+        ? {
+            xaxis: { title: axisLabel(spectrogram.x_label) },
+            yaxis: { title: axisLabel(spectrogram.y_label) },
+            margin: { t: 10, r: 10, b: 45, l: 60 },
+            shapes: [
+              // The selected lineout, drawn as a vertical rule so the scrubber
+              // and the heatmap always agree about where you are.
+              {
+                type: "line",
+                x0: spectrogram.x[lineoutIndex] ?? null,
+                x1: spectrogram.x[lineoutIndex] ?? null,
+                yref: "paper",
+                y0: 0,
+                y1: 1,
+                line: { color: "#ff7f0e", width: 1.5, dash: "dot" },
+              },
+            ],
+          }
+        : {},
+    [spectrogram, lineoutIndex],
+  );
 
   return (
     <section className="panel" aria-labelledby="spectrogram-heading">

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,100 @@
+/**
+ * Config tree flattening and diffing.
+ *
+ * Two ways a run records its config, which is why the diff is conditional:
+ *
+ * - **App-queued runs** log a single `config.yaml` — already the merged result,
+ *   so there is nothing to diff against.
+ * - **NERSC-queued runs** log `defaults.yaml` *and* `inputs.yaml`, where inputs
+ *   overrides defaults. Diffing those answers "what did this run actually
+ *   change?", which is the useful question.
+ *
+ * The run detail response also carries `config`, the tree rebuilt from logged
+ * params. That is the authoritative merged view and is always shown; the diff is
+ * an extra when both YAML files are present.
+ */
+
+export type ConfigValue = unknown;
+
+/** Flatten a nested config to dotted keys, matching how tsadar logs params
+ *  (`flatten_dict` with a dot reducer in `misc.log_mlflow`). */
+export function flattenConfig(value: ConfigValue, prefix = ""): Record<string, ConfigValue> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return prefix ? { [prefix]: value } : {};
+  }
+
+  const flat: Record<string, ConfigValue> = {};
+  for (const [key, child] of Object.entries(value as Record<string, ConfigValue>)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    Object.assign(flat, flattenConfig(child, path));
+  }
+  return flat;
+}
+
+export type DiffStatus = "changed" | "added" | "removed" | "same";
+
+export interface ConfigDiffRow {
+  key: string;
+  status: DiffStatus;
+  base: ConfigValue;
+  override: ConfigValue;
+}
+
+/** Render a value for comparison and display.
+ *
+ *  Compared as JSON so nested arrays and objects diff structurally rather than
+ *  by reference. */
+export function displayValue(value: ConfigValue): string {
+  if (value === undefined) return "—";
+  if (value === null) return "null";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/** Diff an override config against a base, keyed by flattened path. */
+export function diffConfigs(base: ConfigValue, override: ConfigValue): ConfigDiffRow[] {
+  const flatBase = flattenConfig(base);
+  const flatOverride = flattenConfig(override);
+  const keys = [...new Set([...Object.keys(flatBase), ...Object.keys(flatOverride)])].sort();
+
+  return keys.map((key) => {
+    const inBase = key in flatBase;
+    const inOverride = key in flatOverride;
+    const baseValue = flatBase[key];
+    const overrideValue = flatOverride[key];
+
+    let status: DiffStatus;
+    if (!inBase) status = "added";
+    else if (!inOverride) status = "removed";
+    else status = displayValue(baseValue) === displayValue(overrideValue) ? "same" : "changed";
+
+    return { key, status, base: baseValue, override: overrideValue };
+  });
+}
+
+/** Artifact names that carry config, in the two shapes runs use. */
+export const CONFIG_ARTIFACTS = {
+  merged: "config.yaml",
+  defaults: "defaults.yaml",
+  inputs: "inputs.yaml",
+} as const;
+
+export interface ConfigSources {
+  hasMerged: boolean;
+  hasDefaults: boolean;
+  hasInputs: boolean;
+  /** A diff is only meaningful when both halves exist. */
+  diffable: boolean;
+}
+
+export function configSources(artifactPaths: readonly string[]): ConfigSources {
+  const paths = new Set(artifactPaths);
+  const hasDefaults = paths.has(CONFIG_ARTIFACTS.defaults);
+  const hasInputs = paths.has(CONFIG_ARTIFACTS.inputs);
+  return {
+    hasMerged: paths.has(CONFIG_ARTIFACTS.merged),
+    hasDefaults,
+    hasInputs,
+    diffable: hasDefaults && hasInputs,
+  };
+}

--- a/frontend/src/routes/RunDetail.tsx
+++ b/frontend/src/routes/RunDetail.tsx
@@ -1,0 +1,154 @@
+/**
+ * The page a physicist lives on.
+ *
+ * Layout is chosen from the capability probe (`GET /api/runs/{id}/datasets`)
+ * rather than guessed: a run that cannot be served interactively -- angular, or
+ * predating the artifact contract -- gets the gallery with an honest explanation
+ * of *why*, never a blank panel or an error that reads like a bug.
+ *
+ * The selected lineout lives in the URL alongside the spectrum, so a link can
+ * point at one specific lineout of one specific run.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+
+import { ApiError, api, type DatasetAvailability, type RunDetail as RunDetailModel } from "../api/client";
+import { ArtifactGallery } from "../components/ArtifactGallery";
+import { ConfigPanel } from "../components/ConfigPanel";
+import { LineoutPanel } from "../components/LineoutPanel";
+import { LossPanel } from "../components/LossPanel";
+import { ProfilesPanel } from "../components/ProfilesPanel";
+import { RunHeader } from "../components/RunHeader";
+import { SpectrogramPanel } from "../components/SpectrogramPanel";
+import { ErrorState, LoadingState } from "../components/StateViews";
+
+export function RunDetail() {
+  const { runId = "" } = useParams();
+  const [search, setSearch] = useSearchParams();
+
+  const [run, setRun] = useState<RunDetailModel | null>(null);
+  const [availability, setAvailability] = useState<DatasetAvailability | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadCount, setReloadCount] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setError(null);
+    setRun(null);
+    setAvailability(null);
+
+    // Both in parallel: the probe never errors for a legitimate run, so a
+    // failure here means the run itself could not be read.
+    Promise.all([api.run(runId, controller.signal), api.datasets(runId, controller.signal)])
+      .then(([detail, probe]) => {
+        setRun(detail);
+        setAvailability(probe);
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(cause instanceof ApiError ? cause.message : "Could not load this run.");
+      });
+
+    return () => controller.abort();
+  }, [runId, reloadCount]);
+
+  const spectra = availability?.spectra ?? [];
+  const which = search.get("which") ?? spectra[0]?.which ?? "ele";
+  const lineoutIndex = Number(search.get("lineout") ?? "0") || 0;
+
+  const spectrum = useMemo(
+    () => spectra.find((candidate) => candidate.which === which) ?? spectra[0],
+    [spectra, which],
+  );
+
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      const next = new URLSearchParams(search);
+      next.set(key, value);
+      setSearch(next, { replace: true });
+    },
+    [search, setSearch],
+  );
+
+  const onWhichChange = useCallback(
+    (nextWhich: string) => {
+      // Lineout indices are per-spectrum, and ele/ion can have different counts,
+      // so switching spectrum resets to the first lineout rather than carrying
+      // over an index that may not exist.
+      const next = new URLSearchParams(search);
+      next.set("which", nextWhich);
+      next.set("lineout", "0");
+      setSearch(next, { replace: true });
+    },
+    [search, setSearch],
+  );
+
+  const onLineoutChange = useCallback(
+    (index: number) => setParam("lineout", String(index)),
+    [setParam],
+  );
+
+  if (error) {
+    return (
+      <ErrorState message={error} onRetry={() => setReloadCount((count) => count + 1)} />
+    );
+  }
+  if (!run || !availability) return <LoadingState />;
+
+  const interactive = availability.supported && spectrum !== undefined;
+
+  return (
+    <article className="detail">
+      <RunHeader run={run} />
+
+      {interactive ? (
+        <>
+          <SpectrogramPanel
+            runId={runId}
+            spectra={spectra}
+            which={spectrum.which}
+            onWhichChange={onWhichChange}
+            lineoutIndex={lineoutIndex}
+            onLineoutChange={onLineoutChange}
+          />
+          <LineoutPanel
+            runId={runId}
+            spectrum={spectrum}
+            which={spectrum.which}
+            index={lineoutIndex}
+            onIndexChange={onLineoutChange}
+          />
+          {availability.profiles_available && (
+            <ProfilesPanel
+              runId={runId}
+              lineoutIndex={lineoutIndex}
+              onLineoutChange={onLineoutChange}
+            />
+          )}
+        </>
+      ) : (
+        // No interactive views. The message comes from the backend's reason code,
+        // so "angular run, out of scope" never reads as "no data found".
+        <section className="panel">
+          <h2>Interactive views unavailable</h2>
+          <p className="panel__status panel__status--notice" role="status">
+            {availability.message ?? "This run has no readable datasets."}
+          </p>
+        </section>
+      )}
+
+      <LossPanel runId={runId} run={run} />
+      <ConfigPanel runId={runId} run={run} />
+      <ArtifactGallery
+        runId={runId}
+        artifacts={run.artifacts}
+        fallbackMessage={
+          interactive
+            ? null
+            : "Showing the plots this run logged instead of the interactive panels."
+        }
+      />
+    </article>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -238,3 +238,298 @@ body {
 .browser__footer-error {
   color: var(--danger);
 }
+
+/* -- run detail -- */
+
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.runheader__title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.runheader__title h1 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.runheader__back {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.runheader__back:hover {
+  color: var(--accent);
+}
+
+.runheader__mlflow {
+  margin-left: auto;
+}
+
+.badge {
+  padding: 0.1rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.badge--muted {
+  color: var(--muted);
+}
+
+.runheader__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.5rem;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.runheader__fact dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.runheader__fact dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.runheader__runid {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.9rem 1rem 1rem;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.6rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.panel__meta,
+.panel__note {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.panel__note {
+  margin: 0.5rem 0 0;
+}
+
+.panel__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-left: auto;
+}
+
+.panel__status {
+  color: var(--muted);
+  padding: 0.6rem 0;
+  margin: 0;
+}
+
+.panel__status--error {
+  color: var(--danger);
+}
+
+.panel__status--notice {
+  color: var(--text);
+  background: var(--surface);
+  border-left: 3px solid var(--accent);
+  padding: 0.6rem 0.75rem;
+  border-radius: 4px;
+}
+
+.control {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.control--inline {
+  margin: 0.5rem 0;
+}
+
+.control select {
+  padding: 0.25rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+}
+
+.segmented {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.segmented__option {
+  padding: 0.25rem 0.6rem;
+  border: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.segmented__option--active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.segmented__option:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.plot {
+  width: 100%;
+}
+
+.scrubber {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.scrubber__label {
+  font-size: 0.8rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.scrubber input[type="range"] {
+  flex: 1;
+}
+
+.profiles__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+  gap: 0.5rem;
+}
+
+/* -- config -- */
+
+.config__tree,
+.config__node {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.config__key {
+  color: var(--muted);
+  margin-right: 0.4rem;
+}
+
+.config__value {
+  font-variant-numeric: tabular-nums;
+}
+
+.difftable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  display: block;
+  overflow-x: auto;
+}
+
+.difftable th,
+.difftable td {
+  text-align: left;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.difftable__row--changed td:last-child {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.difftable__row--added td:last-child {
+  color: var(--ok);
+}
+
+.difftable__row--removed td:nth-child(2) {
+  color: var(--danger);
+}
+
+/* -- gallery -- */
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 15rem), 1fr));
+  gap: 0.75rem;
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+}
+
+.gallery__item a {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.gallery__item img {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #fff;
+}
+
+.gallery__caption {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 0.2rem;
+  overflow-wrap: anywhere;
+}
+
+.filelist {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+}
+
+.filelist li {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.15rem 0;
+}
+
+.filelist__size {
+  color: var(--muted);
+}

--- a/frontend/src/types/plotly.d.ts
+++ b/frontend/src/types/plotly.d.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal declarations for `plotly.js-cartesian-dist-min`, which ships no types.
+ *
+ * Deliberately narrow rather than pulling in @types/plotly.js: only the handful
+ * of calls `components/Plot.tsx` makes are declared, so the surface stays
+ * obvious and the dependency stays small.
+ *
+ * The *cartesian* bundle, not the full one: it carries heatmap and scatter --
+ * everything these panels draw -- at 1.4 MB instead of 4.7 MB.
+ */
+declare module "plotly.js-cartesian-dist-min" {
+  export interface PlotlyClickPoint {
+    x?: number | string;
+    y?: number | string;
+    pointIndex?: number;
+    pointNumber?: number;
+    curveNumber?: number;
+  }
+
+  export interface PlotlyClickEvent {
+    points: PlotlyClickPoint[];
+  }
+
+  /** The div Plotly attaches its event emitter to. */
+  export interface PlotlyHTMLElement extends HTMLDivElement {
+    on(event: "plotly_click", handler: (event: PlotlyClickEvent) => void): void;
+    removeAllListeners?(event: string): void;
+  }
+
+  export function react(
+    element: HTMLElement,
+    data: unknown[],
+    layout?: unknown,
+    config?: unknown,
+  ): Promise<PlotlyHTMLElement>;
+
+  export function purge(element: HTMLElement): void;
+}


### PR DESCRIPTION
Closes #32. Based on `main` — #40 and #41 have both landed, so no stacking this time.

The page a physicist lives on: header, spectrogram, lineout scrubber, profiles, loss, config and gallery. Everything interactive renders from #30's slicing endpoints; static artifacts come through #29's passthrough.

## Layout is probed, not guessed

`GET /api/runs/{id}/datasets` decides the layout in one call, so a run that can't be served interactively gets the gallery **plus the backend's own reason**. An angular run is out of scope by design, not broken, and the page says exactly that instead of showing an error — and it's never blank. Tested: the slicing endpoints aren't even requested for an unsupported run.

## The three interactive panels are one linked view

A single lineout index lives in the URL, so a link can point at a specific lineout of a specific run. Clicking a spectrogram column, dragging the scrubber, or clicking a profile point all move the same marker. Switching spectrum resets the index, because ele and ion can have different lineout counts and carrying one over could land out of range.

## Details that come from what the data actually is

- **No `irf` toggle on the spectrogram.** IRF and noise aren't in the netCDF datasets, so offering one would promise what the backend can't serve. The lineout panel instead says where those components *do* exist — in the pre-rendered images below. There's a test asserting the toggle is exactly `data | fit | residual`.
- **Residual gets a diverging scale centred at zero**, because it's signed; a sequential scale would hide which way the fit is off.
- **The panel states what downsampling was applied** ("Block-averaged 8× in wavelength from 6 × 32") rather than letting the plot imply full resolution.
- **The loss panel picks from what the run logged**, preferring a per-step key. There is no metric named `loss` — the real names are `epoch loss`, `overall loss`, `min loss`, `batch loss`, with spaces — so the `metrics/loss` this issue originally specified would have 404'd on every run. `overall loss` is usually one summary point, so `epoch loss` is preferred for an actual curve, and the panel says so when you're looking at a single point.
- **The config diff is conditional.** App-queued runs log a single merged `config.yaml`, so the control is disabled with an explanation rather than showing an empty table. NERSC-queued runs log `defaults.yaml` *and* `inputs.yaml`, which diff to answer "what did I actually vary?" — changed-keys-only by default. The merged tree from logged params is always available either way.
- **The gallery is always shown, not only as a fallback.** Even a fully interactive run has images the slicing API can't reproduce: distribution-function contours, the error histogram, and the lineout plots that *do* include IRF and noise.
- **Status and stage stay two badges.** A `FAILED` run whose stage reads `minimizing` tells you where it died; one badge would lose that.

## Plot lifecycle

`Plot` runs two effects, and the split is deliberate. The update effect calls `Plotly.react` only; a separate mount-only effect owns `Plotly.purge`. Purging on every data change would tear the graph down and rebuild it — losing the user's zoom and pan, and forcing a full redraw where `react` diffs. It would also be racy, since both the purge and the next `react` are asynchronous with nothing ordering them. `Plot.test.tsx` pins both properties: `react` twice and `purge` zero times across a data change, `purge` exactly once on unmount.

The two heaviest panels memoize what they hand to `Plot`, since it re-plots on identity. The spectrogram's traces don't depend on `lineoutIndex` at all — only the marker in its layout does — so dragging the scrubber no longer rebuilds the heatmap.

## Bundle size

Plotly is confined to `components/Plot.tsx` and dynamically imported, so the run browser never pays for a charting library it doesn't use. From vite's own build output:

```
index.js                    385.00 kB │ gzip: 122.12 kB   (loaded always)
plotly-cartesian.min.js   1,426.08 kB │ gzip: 475.35 kB   (loaded on this page only)
```

I switched to the **cartesian** bundle rather than the full one after checking it actually has what we draw — `heatmap` and `scatter` are both in it, at 1.4 MB minified instead of the full dist's ~4.7 MB. Only the cartesian bundle is installed here, so that 4.7 MB is the package's published figure rather than something measured in this tree; the 475 kB gzip above is measured, and is what a physicist actually waits for.

## Testing

83 frontend tests (53 new), 144 backend unchanged.

```
$ npm run typecheck && npm test
Test Files  7 passed (7)
     Tests  83 passed (83)
```

jsdom can't render Plotly (no canvas or WebGL), so panels mock that one component and assert on **the traces they build** — which is the part worth testing. Whether Plotly draws a heatmap correctly is Plotly's problem; whether the fit array reaches the chart when the user asks for the fit is ours. `Plot.test.tsx` covers the wrapper the panels mock away, by mocking Plotly at the module boundary instead.

The config diff logic is unit-tested separately, including that arrays are treated as leaves (`other.lamrangE` stays `[400, 700]` rather than splitting into `lamrangE.0` / `lamrangE.1`, which would make the diff unreadable).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM8XjWjnJ1iKv19BS9c9Ab)_