### PR TITLE
Browser frontend: multi-run compare view

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,8 @@
 # Thomson analysis browser — frontend
 
 A Vite + React + TypeScript SPA over the read layer in `tsadar_browser/`
-([#29]). This covers the scaffold and run browser ([#31]) and the run detail view
-([#32]); the compare view is [#33].
+([#29]): the scaffold and run browser ([#31]), the run detail view ([#32]) and the
+multi-run compare view ([#33]).
 
 ## Running it
 
@@ -116,6 +116,40 @@ from logged params by the backend, is always available either way.
 run has images the slicing API cannot reproduce: the distribution-function
 contours, the error histogram, and the lineout plots that *do* include IRF and
 noise components — which the netCDF datasets do not carry.
+
+## The compare view
+
+`/compare?runs=a,b,c` fully encodes the comparison so it can be pasted into Slack,
+which also means the run ids are arbitrary user input rather than a selection made
+in the run browser — every incompatibility has to be handled in the view.
+
+The hard part is not plotting; it is knowing when a comparison would be
+meaningless:
+
+- **Angular runs are excluded from the overlays, with a reason.** Their x axis is
+  scattering angle, so putting one on the same axis as `Time (ps)` is not a
+  degraded comparison but a meaningless one. Excluded-and-why, never silently
+  dropped: a run missing from a legend with no explanation looks like a bug.
+- **The config diff is the exception and stays inclusive.** Flattened key →
+  per-run values doesn't care about axis semantics, so an angular run's config is
+  still perfectly comparable and appears in that table even though its profiles
+  cannot be overlaid.
+- **Mixing spatial and temporal 1D runs is the same problem, milder.** Both are
+  1D, but `Radius (μm)` and `Time (ps)` still aren't the same axis. Those are
+  plotted with a warning, since a deliberate comparison is imaginable and the axis
+  label alone wouldn't flag it.
+- **Runs legitimately differ in which parameters they fitted.** An ele-only run has
+  no ion parameters, so the union of series is taken and each panel says how many
+  runs contributed. Dropping a parameter because one run lacks it would hide data
+  the others do have.
+- **Loss metrics differ between runs.** The summary table names each run's
+  `loss_key` and warns when the column mixes metrics; the curve panel offers the
+  union of keys and names the runs that didn't log the selected one.
+- **A key absent from one run is distinct from a differing value**, and the diff
+  says `absent` rather than leaving a blank cell.
+
+One run failing to load doesn't fail the page: the others are still compared and
+the failure is reported.
 
 ## Testing notes
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,8 @@
-/**
- * Routes. `/compare` stays a placeholder so the URL contract the run browser
- * links into is fixed; the view itself lands with #33.
- */
+/** Routes. */
 
 import { Link, Navigate, Route, Routes } from "react-router-dom";
 
+import { Compare } from "./routes/Compare";
 import { RunBrowser } from "./routes/RunBrowser";
 import { RunDetail } from "./routes/RunDetail";
 
@@ -27,15 +25,7 @@ export function App() {
         <Route path="/" element={<Navigate to="/runs" replace />} />
         <Route path="/runs" element={<RunBrowser />} />
         <Route path="/runs/:runId" element={<RunDetail />} />
-        <Route
-          path="/compare"
-          element={
-            <Placeholder
-              title="Compare runs"
-              detail="The multi-run compare view arrives with issue #33."
-            />
-          }
-        />
+        <Route path="/compare" element={<Compare />} />
         <Route
           path="*"
           element={<Placeholder title="Not found" detail="That page does not exist." />}

--- a/frontend/src/__tests__/Compare.test.tsx
+++ b/frontend/src/__tests__/Compare.test.tsx
@@ -12,6 +12,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Compare } from "../routes/Compare";
+import { MAX_COMPARE_RUNS } from "../lib/compare";
 import { angularAvailability, availability, metricHistory, profiles, runDetail } from "./fixtures";
 
 const plotCalls: Array<{ data: unknown[]; layout?: Record<string, unknown>; ariaLabel?: string }> = [];
@@ -218,6 +219,59 @@ describe("angular runs are excluded, not reconciled", () => {
     renderCompare("/compare?runs=ang");
     await waitFor(() => expect(screen.getByText("Not included in the overlays:")).toBeInTheDocument());
     expect(requested.some((url) => url.includes("/profiles"))).toBe(false);
+  });
+
+  it("says a run logged no profiles when the probe reports none", async () => {
+    stubRuns({ a: {}, none: { probe: availability({ profiles_available: false }) } });
+    renderCompare("/compare?runs=a,none");
+
+    await waitFor(() => expect(screen.getByText("Not included in the overlays:")).toBeInTheDocument());
+    expect(screen.getByText(/No fitted-parameter profiles logged/i)).toBeInTheDocument();
+  });
+
+  it("distinguishes a failed profiles request from a run with no profiles", async () => {
+    // The probe said profiles exist and the request still failed, so this is a
+    // retryable error rather than a property of the run. Reporting it as "no
+    // profiles logged" would send someone looking at their input deck instead.
+    stubRuns({ a: {}, broken: { profiles: null } });
+    renderCompare("/compare?runs=a,broken");
+
+    await waitFor(() => expect(screen.getByText("Not included in the overlays:")).toBeInTheDocument());
+    const notice = screen.getByText("Not included in the overlays:").closest("div")!;
+    expect(within(notice).getByText(/Could not load this run's parameter profiles/i)).toBeInTheDocument();
+    expect(within(notice).getByText(/run not found/)).toBeInTheDocument();
+    expect(within(notice).queryByText(/No fitted-parameter profiles logged/i)).not.toBeInTheDocument();
+
+    // The other run still overlays, and the config diff still covers both.
+    expect(screen.getByText("1 of 2 runs overlaid")).toBeInTheDocument();
+  });
+});
+
+describe("run cap", () => {
+  it("loads at most MAX_COMPARE_RUNS and says what it dropped", async () => {
+    const ids = Array.from({ length: MAX_COMPARE_RUNS + 4 }, (_, index) => `r${index}`);
+    stubRuns(Object.fromEntries(ids.map((id) => [id, {}])));
+    renderCompare(`/compare?runs=${ids.join(",")}`);
+
+    await waitFor(() =>
+      expect(screen.getByText(`Comparing ${MAX_COMPARE_RUNS} runs`)).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText(new RegExp(`asked for ${MAX_COMPARE_RUNS + 4} runs`))).toBeInTheDocument();
+
+    // The cap has to bound the requests, not just the rendering: the four runs
+    // past the limit are never fetched at all.
+    for (const dropped of ids.slice(MAX_COMPARE_RUNS)) {
+      expect(requested.some((url) => url.includes(`/api/runs/${dropped}`))).toBe(false);
+    }
+  });
+
+  it("shows no cap notice when the URL is within the limit", async () => {
+    stubRuns({ a: {}, b: {} });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => expect(screen.getByText("Comparing 2 runs")).toBeInTheDocument());
+    expect(screen.queryByText(/asked for/)).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/__tests__/Compare.test.tsx
+++ b/frontend/src/__tests__/Compare.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * Multi-run compare view (issue #33).
+ *
+ * The behaviour worth pinning is the refusals: which runs get overlaid, which get
+ * excluded-with-a-reason, and the fact that the config diff keeps working for a
+ * selection the overlays reject.
+ */
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Compare } from "../routes/Compare";
+import { angularAvailability, availability, metricHistory, profiles, runDetail } from "./fixtures";
+
+const plotCalls: Array<{ data: unknown[]; layout?: Record<string, unknown>; ariaLabel?: string }> = [];
+
+vi.mock("../components/Plot", () => ({
+  Plot: (props: { data: unknown[]; layout?: Record<string, unknown>; ariaLabel?: string }) => {
+    plotCalls.push(props);
+    return <div data-testid="plot" data-aria={props.ariaLabel} />;
+  },
+}));
+
+interface RunStub {
+  detail?: Record<string, unknown>;
+  probe?: Record<string, unknown>;
+  profiles?: Record<string, unknown> | null;
+  fail?: boolean;
+}
+
+let requested: string[] = [];
+
+function stubRuns(byId: Record<string, RunStub>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      requested.push(url);
+      const runId = url.match(/\/api\/runs\/([^/?]+)/)?.[1] ?? "";
+      const stub = byId[runId];
+      const ok = (body: unknown) =>
+        ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+      const notFound = () =>
+        ({ ok: false, status: 404, json: async () => ({ detail: "run not found" }) }) as unknown as Response;
+
+      if (!stub || stub.fail) return notFound();
+      if (url.includes("/datasets")) return ok(stub.probe ?? availability());
+      if (url.includes("/profiles")) {
+        if (stub.profiles === null) return notFound();
+        return ok(stub.profiles ?? profiles());
+      }
+      if (url.includes("/metrics/")) {
+        const key = decodeURIComponent(url.split("/metrics/")[1] ?? "");
+        return ok(metricHistory(key));
+      }
+      return ok(stub.detail ?? runDetail({ run_id: runId, run_name: runId }));
+    }),
+  );
+}
+
+function renderCompare(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/compare" element={<Compare />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  plotCalls.length = 0;
+  requested = [];
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("entry", () => {
+  it("prompts when no runs are given", async () => {
+    stubRuns({});
+    renderCompare("/compare");
+    expect(screen.getByText("No runs selected")).toBeInTheDocument();
+  });
+
+  it("loads every run in the URL", async () => {
+    stubRuns({ a: {}, b: {} });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => expect(screen.getByText("Comparing 2 runs")).toBeInTheDocument());
+    expect(requested.some((url) => url.includes("/api/runs/a"))).toBe(true);
+    expect(requested.some((url) => url.includes("/api/runs/b"))).toBe(true);
+  });
+
+  it("deduplicates repeated ids from a hand-edited URL", async () => {
+    stubRuns({ a: {} });
+    renderCompare("/compare?runs=a,a,a");
+    await waitFor(() => expect(screen.getByText("Comparing 1 runs")).toBeInTheDocument());
+  });
+});
+
+describe("summary table", () => {
+  it("shows one column per run with its key facts", async () => {
+    stubRuns({ a: {}, b: {} });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => expect(screen.getByRole("link", { name: "a" })).toBeInTheDocument());
+
+    // There are two tables on the page (summary and config diff), so anchor on
+    // the summary's own heading rather than querying by role alone.
+    const summary = within(screen.getByRole("region", { name: "Runs" }));
+    const headers = summary.getAllByRole("columnheader").map((cell) => cell.textContent);
+    expect(headers[0]).toBe("Field");
+    expect(headers[1]).toContain("a");
+    expect(headers[2]).toContain("b");
+
+    const shotRow = summary.getByRole("rowheader", { name: "Shot" }).closest("tr")!;
+    expect(within(shotRow).getAllByRole("cell").map((cell) => cell.textContent)).toEqual([
+      "101675",
+      "101675",
+    ]);
+  });
+
+  it("names each run's loss metric rather than implying comparability", async () => {
+    stubRuns({
+      a: { detail: runDetail({ run_id: "a", run_name: "a", loss_key: "overall loss" }) },
+      b: { detail: runDetail({ run_id: "b", run_name: "b", loss_key: "min loss", final_loss: 3 }) },
+    });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => expect(screen.getByText("(overall loss)")).toBeInTheDocument());
+    expect(screen.getByText("(min loss)")).toBeInTheDocument();
+    // And warns that the row mixes metrics.
+    expect(screen.getByText(/different loss metrics/)).toBeInTheDocument();
+  });
+
+  it("removing a run rewrites the URL rather than hiding it locally", async () => {
+    stubRuns({ a: {}, b: {} });
+    renderCompare("/compare?runs=a,b");
+    await waitFor(() => expect(screen.getByText("Comparing 2 runs")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove a from the comparison" }));
+    await waitFor(() => expect(screen.getByText("Comparing 1 runs")).toBeInTheDocument());
+  });
+});
+
+describe("overlaid profiles", () => {
+  it("puts one trace per run on each parameter plot", async () => {
+    stubRuns({ a: {}, b: {} });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => {
+      const call = plotCalls.find((entry) => entry.ariaLabel === "Te_electron across runs");
+      expect(call).toBeDefined();
+      expect((call!.data as Array<Record<string, unknown>>).map((trace) => trace.name)).toEqual(["a", "b"]);
+    });
+  });
+
+  it("plots a parameter only some runs fitted, and says how many", async () => {
+    // ele-only vs ele+ion: the union is taken so nothing is hidden.
+    stubRuns({
+      a: {},
+      b: {
+        profiles: profiles({
+          series: [{ name: "Te_electron", values: [1, 2, 3, 4, 5, 6], sigma: null }],
+        }),
+      },
+    });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => {
+      const ne = plotCalls.find((entry) => entry.ariaLabel === "ne_electron across runs");
+      expect(ne).toBeDefined();
+      expect((ne!.data as unknown[]).length).toBe(1);
+    });
+    expect(screen.getByText("1 of 2 runs fitted this parameter.")).toBeInTheDocument();
+  });
+});
+
+describe("angular runs are excluded, not reconciled", () => {
+  it("keeps an angular run out of the overlays and says why", async () => {
+    stubRuns({
+      a: {},
+      ang: { probe: angularAvailability(), profiles: null },
+    });
+    renderCompare("/compare?runs=a,ang");
+
+    await waitFor(() => expect(screen.getByText("Not included in the overlays:")).toBeInTheDocument());
+    expect(screen.getByText(/scattering angle/)).toBeInTheDocument();
+
+    // Overlay has only the 1D run.
+    const te = plotCalls.find((entry) => entry.ariaLabel === "Te_electron across runs");
+    expect((te!.data as unknown[]).length).toBe(1);
+    expect(screen.getByText("1 of 2 runs overlaid")).toBeInTheDocument();
+  });
+
+  it("still includes the angular run in the config diff", async () => {
+    // This is the exception the scope note calls out: config comparison does not
+    // care about axis semantics.
+    stubRuns({
+      a: { detail: runDetail({ run_id: "a", run_name: "a", config_flat: { "data.shotnum": "1" } }) },
+      ang: {
+        probe: angularAvailability(),
+        profiles: null,
+        detail: runDetail({ run_id: "ang", run_name: "ang", config_flat: { "data.shotnum": "9" } }),
+      },
+    });
+    renderCompare("/compare?runs=a,ang");
+
+    await waitFor(() => expect(screen.getByText("Config diff")).toBeInTheDocument());
+    const row = screen.getByText("data.shotnum").closest("tr")!;
+    expect(within(row).getByText("1")).toBeInTheDocument();
+    expect(within(row).getByText("9")).toBeInTheDocument();
+  });
+
+  it("does not request profiles for an angular run", async () => {
+    stubRuns({ ang: { probe: angularAvailability(), profiles: null } });
+    renderCompare("/compare?runs=ang");
+    await waitFor(() => expect(screen.getByText("Not included in the overlays:")).toBeInTheDocument());
+    expect(requested.some((url) => url.includes("/profiles"))).toBe(false);
+  });
+});
+
+describe("mixed axes", () => {
+  it("warns when runs do not share a lineout axis", async () => {
+    stubRuns({
+      temporal: {},
+      spatial: { profiles: profiles({ x_label: "Radius (\\mum)" }) },
+    });
+    renderCompare("/compare?runs=temporal,spatial");
+
+    await waitFor(() => expect(screen.getByText(/do not share a lineout axis/)).toBeInTheDocument());
+  });
+});
+
+describe("config diff", () => {
+  it("shows changed keys only by default and can reveal the rest", async () => {
+    stubRuns({
+      a: { detail: runDetail({ run_id: "a", run_name: "a", config_flat: { "data.shotnum": "1", "other.refit": "False" } }) },
+      b: { detail: runDetail({ run_id: "b", run_name: "b", config_flat: { "data.shotnum": "2", "other.refit": "False" } }) },
+    });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => expect(screen.getByText("data.shotnum")).toBeInTheDocument());
+    expect(screen.queryByText("other.refit")).toBeNull();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /Changed keys only/ }));
+    await waitFor(() => expect(screen.getByText("other.refit")).toBeInTheDocument());
+  });
+
+  it("marks a key absent from one run rather than showing it blank", async () => {
+    stubRuns({
+      a: { detail: runDetail({ run_id: "a", run_name: "a", config_flat: { "only.a": "1" } }) },
+      b: { detail: runDetail({ run_id: "b", run_name: "b", config_flat: {} }) },
+    });
+    renderCompare("/compare?runs=a,b");
+
+    await waitFor(() => expect(screen.getByText("only.a")).toBeInTheDocument());
+    expect(within(screen.getByText("only.a").closest("tr")!).getByText("absent")).toBeInTheDocument();
+  });
+
+  it("filters keys", async () => {
+    stubRuns({
+      a: { detail: runDetail({ run_id: "a", run_name: "a", config_flat: { "data.shotnum": "1", "other.thing": "2" } }) },
+      b: { detail: runDetail({ run_id: "b", run_name: "b", config_flat: { "data.shotnum": "9", "other.thing": "8" } }) },
+    });
+    renderCompare("/compare?runs=a,b");
+    await waitFor(() => expect(screen.getByText("data.shotnum")).toBeInTheDocument());
+
+    await userEvent.type(screen.getByPlaceholderText("filter keys"), "shot");
+    await waitFor(() => expect(screen.queryByText("other.thing")).toBeNull());
+    expect(screen.getByText("data.shotnum")).toBeInTheDocument();
+  });
+
+  it("says so when the configs are identical", async () => {
+    stubRuns({
+      a: { detail: runDetail({ run_id: "a", run_name: "a", config_flat: { "x.y": "1" } }) },
+      b: { detail: runDetail({ run_id: "b", run_name: "b", config_flat: { "x.y": "1" } }) },
+    });
+    renderCompare("/compare?runs=a,b");
+    await waitFor(() =>
+      expect(screen.getByText("These runs have identical configurations.")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("loss curves", () => {
+  it("overlays one trace per run", async () => {
+    stubRuns({ a: {}, b: {} });
+    renderCompare("/compare?runs=a,b");
+
+    // The last call, not the first: the panel renders once before the histories
+    // arrive, so the earliest call legitimately has no traces.
+    await waitFor(() => {
+      const loss = plotCalls.filter((entry) => entry.ariaLabel === "epoch loss across runs").at(-1);
+      expect(loss).toBeDefined();
+      expect((loss!.data as unknown[]).length).toBe(2);
+    });
+  });
+
+  it("names runs that did not log the selected metric", async () => {
+    stubRuns({
+      a: {},
+      b: { detail: runDetail({ run_id: "b", run_name: "b", metrics: [{ key: "overall loss", value: 1 }] }) },
+    });
+    renderCompare("/compare?runs=a,b");
+    await waitFor(() => expect(screen.getByText(/Not logged by: b/)).toBeInTheDocument());
+  });
+});
+
+describe("failures", () => {
+  it("compares the runs it could load and reports the ones it could not", async () => {
+    stubRuns({ a: {}, broken: { fail: true } });
+    renderCompare("/compare?runs=a,broken");
+
+    await waitFor(() => expect(screen.getByText("Comparing 1 runs")).toBeInTheDocument());
+    expect(screen.getByRole("alert")).toHaveTextContent(/broken/);
+  });
+
+  it("errors with a retry only when nothing could be loaded", async () => {
+    stubRuns({ x: { fail: true } });
+    renderCompare("/compare?runs=x");
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument());
+  });
+});

--- a/frontend/src/__tests__/compare.test.ts
+++ b/frontend/src/__tests__/compare.test.ts
@@ -5,6 +5,7 @@ import {
   comparableRuns,
   diffAcrossRuns,
   exclusionReason,
+  MAX_COMPARE_RUNS,
   mixedAxisWarning,
   parseRunIds,
   runLabel,
@@ -29,17 +30,39 @@ function comparisonRun(overrides: Partial<ComparisonRun> & { runId: string }): C
 
 describe("parseRunIds", () => {
   it("splits the URL parameter and preserves order", () => {
-    expect(parseRunIds("a,b,c")).toEqual(["a", "b", "c"]);
+    expect(parseRunIds("a,b,c")).toEqual({ ids: ["a", "b", "c"], requested: 3 });
   });
 
   it("drops blanks, whitespace and duplicates", () => {
     // Arbitrary user input: /compare?runs= can be hand-edited.
-    expect(parseRunIds("a, ,b,,a, b ")).toEqual(["a", "b"]);
+    expect(parseRunIds("a, ,b,,a, b ")).toEqual({ ids: ["a", "b"], requested: 2 });
   });
 
   it("handles an absent parameter", () => {
-    expect(parseRunIds(null)).toEqual([]);
-    expect(parseRunIds("")).toEqual([]);
+    expect(parseRunIds(null)).toEqual({ ids: [], requested: 0 });
+    expect(parseRunIds("")).toEqual({ ids: [], requested: 0 });
+  });
+
+  it("caps the comparison and reports what the URL asked for", () => {
+    // A hand-edited URL would otherwise fan out to three requests per run, all
+    // concurrent, with no upper bound.
+    const many = Array.from({ length: MAX_COMPARE_RUNS + 7 }, (_, index) => `run-${index}`);
+    const parsed = parseRunIds(many.join(","));
+
+    expect(parsed.ids).toHaveLength(MAX_COMPARE_RUNS);
+    expect(parsed.requested).toBe(MAX_COMPARE_RUNS + 7);
+    // The first N, not an arbitrary N, so the URL determines which runs you see.
+    expect(parsed.ids).toEqual(many.slice(0, MAX_COMPARE_RUNS));
+  });
+
+  it("counts distinct ids, not commas, when deciding it truncated", () => {
+    // Ten ids repeated is still ten runs, so nothing was dropped and the page
+    // should not claim otherwise.
+    const ten = Array.from({ length: MAX_COMPARE_RUNS }, (_, index) => `run-${index}`);
+    const parsed = parseRunIds([...ten, ...ten].join(","));
+
+    expect(parsed.requested).toBe(MAX_COMPARE_RUNS);
+    expect(parsed.ids).toHaveLength(MAX_COMPARE_RUNS);
   });
 });
 
@@ -66,6 +89,16 @@ describe("exclusionReason", () => {
 
   it("includes a normal 1D run", () => {
     expect(exclusionReason(availability() as never, profiles() as never)).toBeNull();
+  });
+
+  it("distinguishes a failed profiles request from a run with no profiles", () => {
+    // Both leave `profiles` null, but only one is worth retrying, and telling
+    // someone their run has no fitted parameters when the server errored sends
+    // them looking in the wrong place.
+    const reason = exclusionReason(availability() as never, null, "request failed (500)");
+    expect(reason).toMatch(/could not load/i);
+    expect(reason).toMatch(/request failed \(500\)/);
+    expect(reason).not.toMatch(/no fitted-parameter profiles/i);
   });
 });
 

--- a/frontend/src/__tests__/compare.test.ts
+++ b/frontend/src/__tests__/compare.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  axisLabels,
+  comparableRuns,
+  diffAcrossRuns,
+  exclusionReason,
+  mixedAxisWarning,
+  parseRunIds,
+  runLabel,
+  runsWithSeries,
+  sharedSeriesNames,
+  type ComparisonRun,
+} from "../lib/compare";
+import { angularAvailability, availability, profiles, runDetail } from "./fixtures";
+
+function comparisonRun(overrides: Partial<ComparisonRun> & { runId: string }): ComparisonRun {
+  const detail = (overrides.detail ?? runDetail({ run_id: overrides.runId })) as ComparisonRun["detail"];
+  const probe = (overrides.availability ?? availability()) as ComparisonRun["availability"];
+  const runProfiles = overrides.profiles === undefined ? (profiles() as ComparisonRun["profiles"]) : overrides.profiles;
+  return {
+    runId: overrides.runId,
+    detail,
+    availability: probe,
+    profiles: runProfiles,
+    excluded: overrides.excluded ?? exclusionReason(probe, runProfiles),
+  };
+}
+
+describe("parseRunIds", () => {
+  it("splits the URL parameter and preserves order", () => {
+    expect(parseRunIds("a,b,c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops blanks, whitespace and duplicates", () => {
+    // Arbitrary user input: /compare?runs= can be hand-edited.
+    expect(parseRunIds("a, ,b,,a, b ")).toEqual(["a", "b"]);
+  });
+
+  it("handles an absent parameter", () => {
+    expect(parseRunIds(null)).toEqual([]);
+    expect(parseRunIds("")).toEqual([]);
+  });
+});
+
+describe("exclusionReason", () => {
+  it("excludes an angular run and explains why", () => {
+    const reason = exclusionReason(angularAvailability() as never, null);
+    expect(reason).toMatch(/scattering angle/);
+    expect(reason).toMatch(/config still appears/);
+  });
+
+  it("excludes a run with no readable datasets, using the backend's message", () => {
+    const probe = availability({
+      kind: "unknown",
+      supported: false,
+      message: "This run has no readable fit/data datasets.",
+      spectra: [],
+    });
+    expect(exclusionReason(probe as never, null)).toBe("This run has no readable fit/data datasets.");
+  });
+
+  it("excludes a supported run that logged no profiles", () => {
+    expect(exclusionReason(availability() as never, null)).toMatch(/no fitted-parameter profiles/i);
+  });
+
+  it("includes a normal 1D run", () => {
+    expect(exclusionReason(availability() as never, profiles() as never)).toBeNull();
+  });
+});
+
+describe("axis compatibility", () => {
+  it("warns when runs do not share a lineout axis", () => {
+    // Radius (μm) and Time (ps) are both 1D but are not the same axis.
+    const runs = [
+      comparisonRun({ runId: "a" }),
+      comparisonRun({
+        runId: "b",
+        profiles: profiles({ x_label: "Radius (\\mum)" }) as never,
+      }),
+    ];
+    const warning = mixedAxisWarning(runs);
+    expect(warning).toMatch(/do not share a lineout axis/);
+    expect(warning).toContain("Time (ps)");
+  });
+
+  it("is silent when the axes agree", () => {
+    const runs = [comparisonRun({ runId: "a" }), comparisonRun({ runId: "b" })];
+    expect(mixedAxisWarning(runs)).toBeNull();
+  });
+
+  it("ignores excluded runs when deciding, since they are not overlaid", () => {
+    const runs = [
+      comparisonRun({ runId: "a" }),
+      comparisonRun({ runId: "angular", availability: angularAvailability() as never, profiles: null }),
+    ];
+    expect(axisLabels(runs)).toEqual(["Time (ps)"]);
+    expect(mixedAxisWarning(runs)).toBeNull();
+  });
+});
+
+describe("series union across runs", () => {
+  it("takes the union so a parameter one run lacks is still plotted", () => {
+    // An ele-only run has no ion parameters; dropping Ti_ion would hide data the
+    // other run does have.
+    const runs = [
+      comparisonRun({ runId: "a" }),
+      comparisonRun({
+        runId: "b",
+        profiles: profiles({
+          series: [
+            { name: "Te_electron", values: [1, 2, 3, 4, 5, 6], sigma: null },
+            { name: "Ti_ion", values: [1, 2, 3, 4, 5, 6], sigma: null },
+          ],
+        }) as never,
+      }),
+    ];
+    expect(sharedSeriesNames(runs)).toEqual(["Te_electron", "Ti_ion", "ne_electron"]);
+  });
+
+  it("reports which runs actually have a series", () => {
+    const runs = [
+      comparisonRun({ runId: "a" }),
+      comparisonRun({
+        runId: "b",
+        profiles: profiles({ series: [{ name: "Te_electron", values: [1], sigma: null }] }) as never,
+      }),
+    ];
+    expect(runsWithSeries(runs, "Te_electron").map((run) => run.runId)).toEqual(["a", "b"]);
+    expect(runsWithSeries(runs, "ne_electron").map((run) => run.runId)).toEqual(["a"]);
+  });
+
+  it("excludes non-overlayable runs from the union", () => {
+    const runs = [
+      comparisonRun({ runId: "angular", availability: angularAvailability() as never, profiles: null }),
+    ];
+    expect(comparableRuns(runs)).toEqual([]);
+    expect(sharedSeriesNames(runs)).toEqual([]);
+  });
+});
+
+describe("diffAcrossRuns", () => {
+  it("puts one column per run keyed by flattened param", () => {
+    const runs = [
+      comparisonRun({
+        runId: "a",
+        detail: runDetail({ config_flat: { "data.shotnum": "1", "other.refit": "False" } }) as never,
+      }),
+      comparisonRun({
+        runId: "b",
+        detail: runDetail({ config_flat: { "data.shotnum": "2", "other.refit": "False" } }) as never,
+      }),
+    ];
+    const byKey = new Map(diffAcrossRuns(runs).map((row) => [row.key, row]));
+
+    expect(byKey.get("data.shotnum")?.values).toEqual(["1", "2"]);
+    expect(byKey.get("data.shotnum")?.varies).toBe(true);
+    expect(byKey.get("other.refit")?.varies).toBe(false);
+  });
+
+  it("treats a key absent from one run as varying, and marks it undefined", () => {
+    // Different decks: absent is not the same as a different value.
+    const runs = [
+      comparisonRun({ runId: "a", detail: runDetail({ config_flat: { "a.b": "1" } }) as never }),
+      comparisonRun({ runId: "b", detail: runDetail({ config_flat: {} }) as never }),
+    ];
+    const row = diffAcrossRuns(runs)[0]!;
+    expect(row.values).toEqual(["1", undefined]);
+    expect(row.varies).toBe(true);
+  });
+
+  it("includes angular runs, whose config is still comparable", () => {
+    const runs = [
+      comparisonRun({ runId: "a", detail: runDetail({ config_flat: { "data.shotnum": "1" } }) as never }),
+      comparisonRun({
+        runId: "angular",
+        availability: angularAvailability() as never,
+        profiles: null,
+        detail: runDetail({ config_flat: { "data.shotnum": "9" } }) as never,
+      }),
+    ];
+    expect(diffAcrossRuns(runs)[0]?.values).toEqual(["1", "9"]);
+  });
+
+  it("is sorted by key for a stable table", () => {
+    const runs = [
+      comparisonRun({
+        runId: "a",
+        detail: runDetail({ config_flat: { "z.z": "1", "a.a": "2" } }) as never,
+      }),
+    ];
+    expect(diffAcrossRuns(runs).map((row) => row.key)).toEqual(["a.a", "z.z"]);
+  });
+});
+
+describe("runLabel", () => {
+  it("prefers the run name", () => {
+    expect(runLabel(comparisonRun({ runId: "a" }))).toBe("shot-101675-scan");
+  });
+
+  it("falls back to the shot, then a short id", () => {
+    expect(
+      runLabel(comparisonRun({ runId: "a", detail: runDetail({ run_name: null }) as never })),
+    ).toBe("shot 101675");
+    expect(
+      runLabel(
+        comparisonRun({
+          runId: "abcdefghijkl",
+          detail: runDetail({ run_name: null, shot: null, run_id: "abcdefghijkl" }) as never,
+        }),
+      ),
+    ).toBe("abcdefgh");
+  });
+});

--- a/frontend/src/components/CompareConfig.tsx
+++ b/frontend/src/components/CompareConfig.tsx
@@ -1,0 +1,93 @@
+/**
+ * N-way config diff: flattened key → one column per run.
+ *
+ * This is the panel that answers "what did I actually vary?", and it is
+ * deliberately the one thing that still works for a selection the overlays
+ * refuse — comparing an angular run's config against a 1D run's is perfectly
+ * meaningful even though their profiles cannot share an axis.
+ */
+
+import { useMemo, useState } from "react";
+
+import { diffAcrossRuns, runLabel, type ComparisonRun } from "../lib/compare";
+
+export function CompareConfig({ runs }: { runs: ComparisonRun[] }) {
+  const rows = useMemo(() => diffAcrossRuns(runs), [runs]);
+  const [changedOnly, setChangedOnly] = useState(true);
+  const [filter, setFilter] = useState("");
+
+  const varying = rows.filter((row) => row.varies).length;
+
+  const visible = rows
+    .filter((row) => (changedOnly ? row.varies : true))
+    .filter((row) => (filter ? row.key.toLowerCase().includes(filter.toLowerCase()) : true));
+
+  return (
+    <section className="panel" aria-labelledby="compare-config-heading">
+      <header className="panel__header">
+        <h2 id="compare-config-heading">Config diff</h2>
+        <div className="panel__controls">
+          <label className="control control--inline">
+            <input
+              type="checkbox"
+              checked={changedOnly}
+              onChange={(event) => setChangedOnly(event.target.checked)}
+            />
+            <span>Changed keys only ({varying})</span>
+          </label>
+          <label className="control">
+            <span className="visually-hidden">Filter keys</span>
+            <input
+              type="search"
+              placeholder="filter keys"
+              value={filter}
+              onChange={(event) => setFilter(event.target.value)}
+            />
+          </label>
+        </div>
+      </header>
+
+      <div className="comparetable__scroll">
+        <table className="comparetable comparetable--diff">
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              {runs.map((run) => (
+                <th key={run.runId} scope="col">
+                  {runLabel(run)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((row) => (
+              <tr key={row.key} className={row.varies ? "comparetable__row--varies" : undefined}>
+                <th scope="row">{row.key}</th>
+                {row.values.map((value, index) => (
+                  <td
+                    key={runs[index]?.runId ?? index}
+                    // An absent key is different from a differing value, and the
+                    // distinction matters when runs came from different decks.
+                    className={value === undefined ? "comparetable__absent" : undefined}
+                  >
+                    {value ?? "absent"}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {visible.length === 0 && (
+        <p className="panel__status">
+          {filter
+            ? `No keys match "${filter}".`
+            : changedOnly
+              ? "These runs have identical configurations."
+              : "No config parameters were logged."}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/CompareLoss.tsx
+++ b/frontend/src/components/CompareLoss.tsx
@@ -1,0 +1,120 @@
+/**
+ * Overlaid loss curves.
+ *
+ * Each run may have logged different loss metric names, so the panel offers the
+ * union and fetches whichever key a run actually has. A run without the selected
+ * key is listed as absent rather than silently missing from the legend.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { api, type MetricHistory } from "../api/client";
+import { runLabel, type ComparisonRun } from "../lib/compare";
+import { Plot } from "./Plot";
+
+const LOSS_PATTERN = /loss/i;
+
+/** Loss metric keys across all runs, per-step ones first. */
+export function lossKeyOptions(runs: ComparisonRun[]): string[] {
+  const keys = new Set<string>();
+  for (const run of runs) {
+    for (const metric of run.detail.metrics) {
+      if (LOSS_PATTERN.test(metric.key)) keys.add(metric.key);
+    }
+  }
+  const rank = (key: string) => (key.includes("epoch") ? 0 : key.includes("batch") ? 1 : 2);
+  return [...keys].sort((left, right) => rank(left) - rank(right) || left.localeCompare(right));
+}
+
+export function CompareLoss({ runs }: { runs: ComparisonRun[] }) {
+  const options = useMemo(() => lossKeyOptions(runs), [runs]);
+  const [selected, setSelected] = useState<string | null>(options[0] ?? null);
+  const [histories, setHistories] = useState<Map<string, MetricHistory>>(new Map());
+  const [missing, setMissing] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!selected) return;
+    const controller = new AbortController();
+
+    const havingKey = runs.filter((run) =>
+      run.detail.metrics.some((metric) => metric.key === selected),
+    );
+
+    setMissing(
+      runs.filter((run) => !havingKey.includes(run)).map((run) => runLabel(run)),
+    );
+
+    Promise.all(
+      havingKey.map((run) =>
+        api
+          .metricHistory(run.runId, selected, controller.signal)
+          .then((history) => [run.runId, history] as const)
+          .catch(() => null),
+      ),
+    ).then((results) => {
+      if (controller.signal.aborted) return;
+      setHistories(new Map(results.filter((entry): entry is [string, MetricHistory] => entry !== null)));
+    });
+
+    return () => controller.abort();
+  }, [runs, selected]);
+
+  if (options.length === 0) {
+    return (
+      <section className="panel">
+        <h2>Loss curves</h2>
+        <p className="panel__status">None of these runs logged a loss metric.</p>
+      </section>
+    );
+  }
+
+  const traces = runs
+    .map((run) => {
+      const history = histories.get(run.runId);
+      if (!history) return null;
+      return {
+        type: "scatter",
+        mode: history.points.length > 1 ? "lines" : "markers",
+        name: runLabel(run),
+        x: history.points.map((point) => point.step),
+        y: history.points.map((point) => point.value),
+      };
+    })
+    .filter((trace): trace is NonNullable<typeof trace> => trace !== null);
+
+  return (
+    <section className="panel" aria-labelledby="compare-loss-heading">
+      <header className="panel__header">
+        <h2 id="compare-loss-heading">Loss curves</h2>
+        <label className="control">
+          <span>Metric</span>
+          <select value={selected ?? ""} onChange={(event) => setSelected(event.target.value)}>
+            {options.map((key) => (
+              <option key={key} value={key}>
+                {key}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      <Plot
+        data={traces}
+        layout={{
+          xaxis: { title: "Step" },
+          yaxis: { title: selected ?? "loss" },
+          margin: { t: 12, r: 16, b: 40, l: 62 },
+          showlegend: true,
+        }}
+        height={280}
+        ariaLabel={`${selected} across runs`}
+      />
+
+      {missing.length > 0 && (
+        <p className="panel__note">
+          Not logged by: {missing.join(", ")}. Runs log different loss metrics, so try another key.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/CompareProfiles.tsx
+++ b/frontend/src/components/CompareProfiles.tsx
@@ -1,0 +1,97 @@
+/**
+ * Overlaid parameter profiles across runs.
+ *
+ * One plot per parameter, one trace per run. Runs legitimately differ in which
+ * parameters they fitted — an ele-only run has no ion parameters — so the union
+ * of series is taken and each panel says how many runs contributed. Dropping a
+ * parameter because one run lacks it would hide data the others do have.
+ */
+
+import { Plot } from "./Plot";
+import { axisLabel } from "../lib/format";
+import {
+  axisLabels,
+  comparableRuns,
+  runLabel,
+  runsWithSeries,
+  sharedSeriesNames,
+  type ComparisonRun,
+} from "../lib/compare";
+import { splitSeriesName } from "./ProfilesPanel";
+
+export function CompareProfiles({ runs }: { runs: ComparisonRun[] }) {
+  const comparable = comparableRuns(runs);
+  const names = sharedSeriesNames(runs);
+  const labels = axisLabels(runs);
+
+  if (comparable.length === 0) {
+    return (
+      <section className="panel">
+        <h2>Parameter profiles</h2>
+        <p className="panel__status">
+          None of the selected runs can be overlaid. See the notes above; the config diff below still
+          works.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel" aria-labelledby="compare-profiles-heading">
+      <header className="panel__header">
+        <h2 id="compare-profiles-heading">Parameter profiles</h2>
+        <span className="panel__meta">
+          {comparable.length} of {runs.length} run{runs.length === 1 ? "" : "s"} overlaid
+        </span>
+      </header>
+
+      <div className="profiles__grid">
+        {names.map((name) => {
+          const contributors = runsWithSeries(runs, name);
+          const { parameter, species } = splitSeriesName(name);
+
+          const traces = contributors.map((run) => {
+            const series = run.profiles!.series.find((candidate) => candidate.name === name)!;
+            return {
+              type: "scatter",
+              mode: "lines+markers",
+              name: runLabel(run),
+              x: run.profiles!.x,
+              y: series.values,
+              error_y: series.sigma
+                ? { type: "data", array: series.sigma, visible: true, thickness: 1 }
+                : undefined,
+            };
+          });
+
+          return (
+            <div key={name} className="profiles__cell">
+              <Plot
+                data={traces}
+                layout={{
+                  title: {
+                    text: species ? `${parameter} (${species})` : parameter,
+                    font: { size: 13 },
+                  },
+                  // With more than one axis label in play the axis title would be
+                  // a lie, so it names both rather than picking one.
+                  xaxis: { title: labels.map(axisLabel).join(" / ") },
+                  margin: { t: 30, r: 12, b: 40, l: 52 },
+                  showlegend: contributors.length > 1,
+                  legend: { orientation: "h", y: -0.25 },
+                }}
+                height={240}
+                ariaLabel={`${name} across runs`}
+              />
+              {contributors.length < comparable.length && (
+                <p className="panel__note">
+                  {contributors.length} of {comparable.length} runs fitted this parameter.
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/CompareProfiles.tsx
+++ b/frontend/src/components/CompareProfiles.tsx
@@ -7,6 +7,8 @@
  * parameter because one run lacks it would hide data the others do have.
  */
 
+import { memo, useMemo } from "react";
+
 import { Plot } from "./Plot";
 import { axisLabel } from "../lib/format";
 import {
@@ -19,10 +21,53 @@ import {
 } from "../lib/compare";
 import { splitSeriesName } from "./ProfilesPanel";
 
-export function CompareProfiles({ runs }: { runs: ComparisonRun[] }) {
-  const comparable = comparableRuns(runs);
-  const names = sharedSeriesNames(runs);
-  const labels = axisLabels(runs);
+function CompareProfilesImpl({ runs }: { runs: ComparisonRun[] }) {
+  const comparable = useMemo(() => comparableRuns(runs), [runs]);
+
+  // One memo for every panel rather than one per panel: `Plot` re-plots when the
+  // arrays it is handed change by identity, and this component renders N panels
+  // from the same `runs`. Building them inline meant any render of this
+  // component -- a parent state change, a removed run -- rebuilt every trace and
+  // every layout for every parameter, and redrew the lot.
+  const panels = useMemo(() => {
+    const labels = axisLabels(runs);
+    const xTitle = labels.map(axisLabel).join(" / ");
+
+    return sharedSeriesNames(runs).map((name) => {
+      const contributors = runsWithSeries(runs, name);
+      const { parameter, species } = splitSeriesName(name);
+
+      return {
+        name,
+        contributors: contributors.length,
+        traces: contributors.map((run) => {
+          const series = run.profiles!.series.find((candidate) => candidate.name === name)!;
+          return {
+            type: "scatter",
+            mode: "lines+markers",
+            name: runLabel(run),
+            x: run.profiles!.x,
+            y: series.values,
+            error_y: series.sigma
+              ? { type: "data", array: series.sigma, visible: true, thickness: 1 }
+              : undefined,
+          };
+        }),
+        layout: {
+          title: {
+            text: species ? `${parameter} (${species})` : parameter,
+            font: { size: 13 },
+          },
+          // With more than one axis label in play the axis title would be a lie,
+          // so it names both rather than picking one.
+          xaxis: { title: xTitle },
+          margin: { t: 30, r: 12, b: 40, l: 52 },
+          showlegend: contributors.length > 1,
+          legend: { orientation: "h", y: -0.25 },
+        },
+      };
+    });
+  }, [runs]);
 
   if (comparable.length === 0) {
     return (
@@ -46,52 +91,26 @@ export function CompareProfiles({ runs }: { runs: ComparisonRun[] }) {
       </header>
 
       <div className="profiles__grid">
-        {names.map((name) => {
-          const contributors = runsWithSeries(runs, name);
-          const { parameter, species } = splitSeriesName(name);
-
-          const traces = contributors.map((run) => {
-            const series = run.profiles!.series.find((candidate) => candidate.name === name)!;
-            return {
-              type: "scatter",
-              mode: "lines+markers",
-              name: runLabel(run),
-              x: run.profiles!.x,
-              y: series.values,
-              error_y: series.sigma
-                ? { type: "data", array: series.sigma, visible: true, thickness: 1 }
-                : undefined,
-            };
-          });
-
-          return (
-            <div key={name} className="profiles__cell">
-              <Plot
-                data={traces}
-                layout={{
-                  title: {
-                    text: species ? `${parameter} (${species})` : parameter,
-                    font: { size: 13 },
-                  },
-                  // With more than one axis label in play the axis title would be
-                  // a lie, so it names both rather than picking one.
-                  xaxis: { title: labels.map(axisLabel).join(" / ") },
-                  margin: { t: 30, r: 12, b: 40, l: 52 },
-                  showlegend: contributors.length > 1,
-                  legend: { orientation: "h", y: -0.25 },
-                }}
-                height={240}
-                ariaLabel={`${name} across runs`}
-              />
-              {contributors.length < comparable.length && (
-                <p className="panel__note">
-                  {contributors.length} of {comparable.length} runs fitted this parameter.
-                </p>
-              )}
-            </div>
-          );
-        })}
+        {panels.map((panel) => (
+          <div key={panel.name} className="profiles__cell">
+            <Plot
+              data={panel.traces}
+              layout={panel.layout}
+              height={240}
+              ariaLabel={`${panel.name} across runs`}
+            />
+            {panel.contributors < comparable.length && (
+              <p className="panel__note">
+                {panel.contributors} of {comparable.length} runs fitted this parameter.
+              </p>
+            )}
+          </div>
+        ))}
       </div>
     </section>
   );
 }
+
+/** Memoized because `runs` only changes when the comparison reloads, while this
+ *  component's parent re-renders on every URL change. */
+export const CompareProfiles = memo(CompareProfilesImpl);

--- a/frontend/src/components/CompareSummary.tsx
+++ b/frontend/src/components/CompareSummary.tsx
@@ -6,6 +6,7 @@
  * `min loss` would invite exactly the wrong conclusion from a comparison.
  */
 
+import { memo, useMemo } from "react";
 import { Link } from "react-router-dom";
 
 import { formatDuration, formatLoss, formatTimestamp, spectypeLabel } from "../lib/format";
@@ -16,9 +17,12 @@ interface CompareSummaryProps {
   onRemove: (runId: string) => void;
 }
 
-export function CompareSummary({ runs, onRemove }: CompareSummaryProps) {
-  const lossKeys = new Set(runs.map((run) => run.detail.loss_key).filter(Boolean));
-  const mixedLossMetrics = lossKeys.size > 1;
+function CompareSummaryImpl({ runs, onRemove }: CompareSummaryProps) {
+  const lossKeys = useMemo(
+    () => [...new Set(runs.map((run) => run.detail.loss_key).filter(Boolean))],
+    [runs],
+  );
+  const mixedLossMetrics = lossKeys.length > 1;
 
   return (
     <section className="panel" aria-labelledby="summary-heading">
@@ -104,10 +108,14 @@ export function CompareSummary({ runs, onRemove }: CompareSummaryProps) {
 
       {mixedLossMetrics && (
         <p className="panel__note">
-          These runs report <strong>different loss metrics</strong> ({[...lossKeys].join(", ")}), so
-          the final-loss row is not directly comparable across all of them.
+          These runs report <strong>different loss metrics</strong> ({lossKeys.join(", ")}), so the
+          final-loss row is not directly comparable across all of them.
         </p>
       )}
     </section>
   );
 }
+
+/** `onRemove` is stable (the route memoizes it), so this only re-renders when the
+ *  comparison itself changes rather than on every parent render. */
+export const CompareSummary = memo(CompareSummaryImpl);

--- a/frontend/src/components/CompareSummary.tsx
+++ b/frontend/src/components/CompareSummary.tsx
@@ -1,0 +1,113 @@
+/**
+ * Side-by-side summary table.
+ *
+ * `loss_key` is shown next to each final loss rather than assumed: runs log
+ * different loss metrics, and a column that silently mixed `overall loss` with
+ * `min loss` would invite exactly the wrong conclusion from a comparison.
+ */
+
+import { Link } from "react-router-dom";
+
+import { formatDuration, formatLoss, formatTimestamp, spectypeLabel } from "../lib/format";
+import { runLabel, type ComparisonRun } from "../lib/compare";
+
+interface CompareSummaryProps {
+  runs: ComparisonRun[];
+  onRemove: (runId: string) => void;
+}
+
+export function CompareSummary({ runs, onRemove }: CompareSummaryProps) {
+  const lossKeys = new Set(runs.map((run) => run.detail.loss_key).filter(Boolean));
+  const mixedLossMetrics = lossKeys.size > 1;
+
+  return (
+    <section className="panel" aria-labelledby="summary-heading">
+      <header className="panel__header">
+        <h2 id="summary-heading">Runs</h2>
+        <span className="panel__meta">{runs.length} selected</span>
+      </header>
+
+      <div className="comparetable__scroll">
+        <table className="comparetable">
+          <thead>
+            <tr>
+              <th scope="col">Field</th>
+              {runs.map((run) => (
+                <th key={run.runId} scope="col">
+                  <Link to={`/runs/${run.runId}`}>{runLabel(run)}</Link>
+                  <button
+                    type="button"
+                    className="comparetable__remove"
+                    aria-label={`Remove ${runLabel(run)} from the comparison`}
+                    onClick={() => onRemove(run.runId)}
+                  >
+                    ×
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Shot</th>
+              {runs.map((run) => (
+                <td key={run.runId}>{run.detail.shot ?? "—"}</td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row">Type</th>
+              {runs.map((run) => (
+                <td key={run.runId}>{spectypeLabel(run.detail.spectype)}</td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row">Status</th>
+              {runs.map((run) => (
+                <td key={run.runId}>
+                  {run.detail.status ?? "—"}
+                  {run.detail.stage && <span className="comparetable__stage"> / {run.detail.stage}</span>}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row">Final loss</th>
+              {runs.map((run) => (
+                <td key={run.runId}>
+                  {formatLoss(run.detail.final_loss)}
+                  {run.detail.loss_key && (
+                    <span className="comparetable__losskey"> ({run.detail.loss_key})</span>
+                  )}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row">Runtime</th>
+              {runs.map((run) => (
+                <td key={run.runId}>{formatDuration(run.detail.duration_s)}</td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row">Started</th>
+              {runs.map((run) => (
+                <td key={run.runId}>{formatTimestamp(run.detail.start_time)}</td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row">User</th>
+              {runs.map((run) => (
+                <td key={run.runId}>{run.detail.user ?? "—"}</td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {mixedLossMetrics && (
+        <p className="panel__note">
+          These runs report <strong>different loss metrics</strong> ({[...lossKeys].join(", ")}), so
+          the final-loss row is not directly comparable across all of them.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useComparison.ts
+++ b/frontend/src/hooks/useComparison.ts
@@ -6,7 +6,7 @@
  * still compare the other three, and say what happened to the fourth.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { ApiError, api, type Profiles } from "../api/client";
 import { exclusionReason, type ComparisonRun } from "../lib/compare";
@@ -28,11 +28,26 @@ async function loadRun(runId: string, signal: AbortSignal): Promise<ComparisonRu
   // Profiles are the overlay's substance, but their absence is not fatal -- the
   // run still contributes to the summary table and the config diff.
   let profiles: Profiles | null = null;
+  let profilesError: string | null = null;
   if (availability.supported && availability.profiles_available) {
-    profiles = await api.profiles(runId, signal).catch(() => null);
+    profiles = await api.profiles(runId, signal).catch((cause: unknown) => {
+      // An abort is not "this run has no profiles" -- it means the comparison
+      // moved on while the request was in flight. Swallowing it would resolve
+      // this run with a wrong exclusion reason, and the caller discards aborted
+      // results anyway, so it is rethrown rather than recorded.
+      if (signal.aborted) throw cause;
+      profilesError = cause instanceof ApiError ? cause.message : "the request failed";
+      return null;
+    });
   }
 
-  return { runId, detail, availability, profiles, excluded: exclusionReason(availability, profiles) };
+  return {
+    runId,
+    detail,
+    availability,
+    profiles,
+    excluded: exclusionReason(availability, profiles, profilesError),
+  };
 }
 
 export function useComparison(runIds: string[]): ComparisonState {
@@ -40,6 +55,10 @@ export function useComparison(runIds: string[]): ComparisonState {
   const [failures, setFailures] = useState<Array<{ runId: string; message: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [reloadCount, setReloadCount] = useState(0);
+
+  // Stable across renders so a consumer can pass it to a memoized child (the
+  // retry button's `onRetry`) without defeating the memo.
+  const reload = useCallback(() => setReloadCount((count) => count + 1), []);
 
   const key = runIds.join(",");
 
@@ -84,5 +103,5 @@ export function useComparison(runIds: string[]): ComparisonState {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, reloadCount]);
 
-  return { runs, failures, loading, reload: () => setReloadCount((count) => count + 1) };
+  return { runs, failures, loading, reload };
 }

--- a/frontend/src/hooks/useComparison.ts
+++ b/frontend/src/hooks/useComparison.ts
@@ -1,0 +1,88 @@
+/**
+ * Load several runs for comparison.
+ *
+ * Each run is fetched independently and a failure is recorded against that run
+ * rather than failing the page: comparing four runs where one is unreadable should
+ * still compare the other three, and say what happened to the fourth.
+ */
+
+import { useEffect, useState } from "react";
+
+import { ApiError, api, type Profiles } from "../api/client";
+import { exclusionReason, type ComparisonRun } from "../lib/compare";
+
+export interface ComparisonState {
+  runs: ComparisonRun[];
+  /** Runs that could not be loaded at all, as run id → message. */
+  failures: Array<{ runId: string; message: string }>;
+  loading: boolean;
+  reload: () => void;
+}
+
+async function loadRun(runId: string, signal: AbortSignal): Promise<ComparisonRun> {
+  const [detail, availability] = await Promise.all([
+    api.run(runId, signal),
+    api.datasets(runId, signal),
+  ]);
+
+  // Profiles are the overlay's substance, but their absence is not fatal -- the
+  // run still contributes to the summary table and the config diff.
+  let profiles: Profiles | null = null;
+  if (availability.supported && availability.profiles_available) {
+    profiles = await api.profiles(runId, signal).catch(() => null);
+  }
+
+  return { runId, detail, availability, profiles, excluded: exclusionReason(availability, profiles) };
+}
+
+export function useComparison(runIds: string[]): ComparisonState {
+  const [runs, setRuns] = useState<ComparisonRun[]>([]);
+  const [failures, setFailures] = useState<Array<{ runId: string; message: string }>>([]);
+  const [loading, setLoading] = useState(true);
+  const [reloadCount, setReloadCount] = useState(0);
+
+  const key = runIds.join(",");
+
+  useEffect(() => {
+    if (runIds.length === 0) {
+      setRuns([]);
+      setFailures([]);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+
+    Promise.all(
+      runIds.map((runId) =>
+        loadRun(runId, controller.signal).then(
+          (run) => ({ ok: true as const, run }),
+          (cause: unknown) => ({
+            ok: false as const,
+            runId,
+            message: cause instanceof ApiError ? cause.message : "Could not load this run.",
+          }),
+        ),
+      ),
+    )
+      .then((results) => {
+        if (controller.signal.aborted) return;
+        setRuns(results.filter((result) => result.ok).map((result) => result.run));
+        setFailures(
+          results
+            .filter((result) => !result.ok)
+            .map((result) => ({ runId: result.runId, message: result.message })),
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+    // runIds is covered by `key`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, reloadCount]);
+
+  return { runs, failures, loading, reload: () => setReloadCount((count) => count + 1) };
+}

--- a/frontend/src/lib/compare.ts
+++ b/frontend/src/lib/compare.ts
@@ -29,13 +29,25 @@ export interface ComparisonRun {
   excluded: string | null;
 }
 
-/** Decide whether a run can be overlaid, and say why not when it cannot. */
-export function exclusionReason(availability: DatasetAvailability, profiles: Profiles | null): string | null {
+/** Decide whether a run can be overlaid, and say why not when it cannot.
+ *
+ *  `profilesError` distinguishes "this run logged no profiles" from "the profiles
+ *  request failed". Both leave `profiles` null and both exclude the run, but only
+ *  one of them is worth retrying, and telling a user their run has no fitted
+ *  parameters when the server merely 500'd sends them looking in the wrong place. */
+export function exclusionReason(
+  availability: DatasetAvailability,
+  profiles: Profiles | null,
+  profilesError: string | null = null,
+): string | null {
   if (availability.kind === "angular") {
     return "Angular run: its x axis is scattering angle, so it cannot share an axis with 1D runs. Its config still appears in the diff.";
   }
   if (!availability.supported) {
     return availability.message ?? "No readable datasets for this run.";
+  }
+  if (profilesError) {
+    return `Could not load this run's parameter profiles: ${profilesError}`;
   }
   if (!profiles) {
     return "No fitted-parameter profiles logged for this run.";
@@ -109,21 +121,38 @@ export function diffAcrossRuns(runs: ComparisonRun[]): MultiConfigRow[] {
   });
 }
 
+/** How many runs a single comparison will load.
+ *
+ *  Chosen from what the overlay can actually express, not from a load estimate:
+ *  Plotly's default colorway has ten entries, so an eleventh trace reuses the
+ *  first colour and two runs become indistinguishable in the legend. It also
+ *  bounds the fan-out -- every run costs up to three requests, all issued
+ *  concurrently -- so a hand-edited URL cannot turn one page load into hundreds
+ *  of them. */
+export const MAX_COMPARE_RUNS = 10;
+
+export interface ParsedRunIds {
+  /** The ids to load: distinct, in URL order, at most `MAX_COMPARE_RUNS`. */
+  ids: string[];
+  /** How many distinct ids the URL asked for, which may exceed `ids.length`. */
+  requested: number;
+}
+
 /** Parse the `runs` query parameter, dropping blanks and duplicates.
  *
- *  Order is preserved so trace colours stay stable for a given URL. */
-export function parseRunIds(raw: string | null): string[] {
-  if (!raw) return [];
+ *  Order is preserved so trace colours stay stable for a given URL, and the cap
+ *  is applied here rather than at the call site so no caller can forget it. The
+ *  requested count is returned alongside so the page can say what it dropped
+ *  instead of silently truncating. */
+export function parseRunIds(raw: string | null): ParsedRunIds {
+  if (!raw) return { ids: [], requested: 0 };
   const seen = new Set<string>();
-  const ids: string[] = [];
   for (const candidate of raw.split(",")) {
     const id = candidate.trim();
-    if (id && !seen.has(id)) {
-      seen.add(id);
-      ids.push(id);
-    }
+    if (id) seen.add(id);
   }
-  return ids;
+  const ids = [...seen];
+  return { ids: ids.slice(0, MAX_COMPARE_RUNS), requested: ids.length };
 }
 
 /** A short label for a run in legends and table headers. */

--- a/frontend/src/lib/compare.ts
+++ b/frontend/src/lib/compare.ts
@@ -1,0 +1,134 @@
+/**
+ * Multi-run comparison logic.
+ *
+ * The hard part of comparing runs is not plotting — it is knowing when a
+ * comparison would be meaningless. Two rules, both from #37's scope decision:
+ *
+ * - **Angular runs cannot be overlaid on 1D runs.** Their x axis is scattering
+ *   angle, so putting one on the same axis as `Time (ps)` produces a chart that
+ *   is not a degraded comparison but a meaningless one. They are excluded with a
+ *   reason rather than reconciled.
+ * - **Mixing spatial and temporal 1D runs is the same problem, milder.** Both are
+ *   1D, but `Radius (μm)` and `Time (ps)` are still not the same axis. Those are
+ *   plotted but flagged, since a deliberate comparison is imaginable and the
+ *   axis label alone would not warn you.
+ *
+ * The config diff is the exception: flattened key → per-run values doesn't care
+ * about axis semantics, so it stays useful even for a selection this module
+ * refuses to overlay.
+ */
+
+import type { DatasetAvailability, Profiles, RunDetail } from "../api/client";
+
+export interface ComparisonRun {
+  runId: string;
+  detail: RunDetail;
+  availability: DatasetAvailability;
+  profiles: Profiles | null;
+  /** Why this run cannot take part in the overlays, when it cannot. */
+  excluded: string | null;
+}
+
+/** Decide whether a run can be overlaid, and say why not when it cannot. */
+export function exclusionReason(availability: DatasetAvailability, profiles: Profiles | null): string | null {
+  if (availability.kind === "angular") {
+    return "Angular run: its x axis is scattering angle, so it cannot share an axis with 1D runs. Its config still appears in the diff.";
+  }
+  if (!availability.supported) {
+    return availability.message ?? "No readable datasets for this run.";
+  }
+  if (!profiles) {
+    return "No fitted-parameter profiles logged for this run.";
+  }
+  return null;
+}
+
+/** Runs that can actually be overlaid. */
+export function comparableRuns(runs: ComparisonRun[]): ComparisonRun[] {
+  return runs.filter((run) => run.excluded === null && run.profiles !== null);
+}
+
+/** Distinct lineout-axis labels among the comparable runs.
+ *
+ *  More than one means the overlay is putting different quantities on one axis. */
+export function axisLabels(runs: ComparisonRun[]): string[] {
+  return [...new Set(comparableRuns(runs).map((run) => run.profiles!.x_label))];
+}
+
+export function mixedAxisWarning(runs: ComparisonRun[]): string | null {
+  const labels = axisLabels(runs);
+  if (labels.length <= 1) return null;
+  return `These runs do not share a lineout axis (${labels.join(", ")}). The overlay puts different quantities on one axis — compare with care.`;
+}
+
+/** Parameter names present across the comparable runs, in a stable order.
+ *
+ *  Runs legitimately differ here: an ele-only run has no ion parameters, and
+ *  which parameters were active varies per run. The union is taken so a
+ *  parameter missing from one run leaves a gap rather than dropping the panel. */
+export function sharedSeriesNames(runs: ComparisonRun[]): string[] {
+  const names = new Set<string>();
+  for (const run of comparableRuns(runs)) {
+    for (const series of run.profiles!.series) names.add(series.name);
+  }
+  return [...names].sort();
+}
+
+/** Which runs actually have a given series, so a panel can say "3 of 4 runs". */
+export function runsWithSeries(runs: ComparisonRun[], name: string): ComparisonRun[] {
+  return comparableRuns(runs).filter((run) =>
+    run.profiles!.series.some((series) => series.name === name),
+  );
+}
+
+// -- config diff across N runs -------------------------------------------------
+
+export interface MultiConfigRow {
+  key: string;
+  /** One entry per run, in the order the runs were given. Undefined where a run
+   *  does not have the key at all. */
+  values: Array<string | undefined>;
+  /** True when the runs do not all agree. */
+  varies: boolean;
+}
+
+/** Diff the flattened configs of N runs.
+ *
+ *  Uses `config_flat` -- the raw params as MLflow stores them -- rather than the
+ *  reconstructed tree, so the comparison is between what was actually logged and
+ *  cannot be skewed by a failed unflattening on one run. */
+export function diffAcrossRuns(runs: ComparisonRun[]): MultiConfigRow[] {
+  const flats = runs.map((run) => run.detail.config_flat ?? {});
+  const keys = [...new Set(flats.flatMap((flat) => Object.keys(flat)))].sort();
+
+  return keys.map((key) => {
+    const values = flats.map((flat) => flat[key]);
+    const present = values.filter((value): value is string => value !== undefined);
+    const varies = present.length !== values.length || new Set(present).size > 1;
+    return { key, values, varies };
+  });
+}
+
+/** Parse the `runs` query parameter, dropping blanks and duplicates.
+ *
+ *  Order is preserved so trace colours stay stable for a given URL. */
+export function parseRunIds(raw: string | null): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const candidate of raw.split(",")) {
+    const id = candidate.trim();
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+/** A short label for a run in legends and table headers. */
+export function runLabel(run: ComparisonRun): string {
+  const { detail } = run;
+  const shot = detail.shot ? `shot ${detail.shot}` : null;
+  return detail.run_name ?? shot ?? detail.run_id.slice(0, 8);
+}

--- a/frontend/src/routes/Compare.tsx
+++ b/frontend/src/routes/Compare.tsx
@@ -1,0 +1,115 @@
+/**
+ * Multi-run comparison.
+ *
+ * `/compare?runs=a,b,c` fully encodes the comparison, so it can be pasted into
+ * Slack. That also means the run ids are arbitrary user input rather than a
+ * selection made in the run browser, so every incompatibility has to be handled
+ * here rather than assumed away upstream.
+ */
+
+import { useCallback, useMemo } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import { CompareConfig } from "../components/CompareConfig";
+import { CompareLoss } from "../components/CompareLoss";
+import { CompareProfiles } from "../components/CompareProfiles";
+import { CompareSummary } from "../components/CompareSummary";
+import { ErrorState, LoadingState } from "../components/StateViews";
+import { useComparison } from "../hooks/useComparison";
+import { mixedAxisWarning, parseRunIds, runLabel } from "../lib/compare";
+
+export function Compare() {
+  const [search, setSearch] = useSearchParams();
+  const runIds = useMemo(() => parseRunIds(search.get("runs")), [search]);
+
+  const { runs, failures, loading, reload } = useComparison(runIds);
+
+  const removeRun = useCallback(
+    (runId: string) => {
+      const next = new URLSearchParams(search);
+      const remaining = runIds.filter((candidate) => candidate !== runId);
+      if (remaining.length) next.set("runs", remaining.join(","));
+      else next.delete("runs");
+      setSearch(next, { replace: true });
+    },
+    [runIds, search, setSearch],
+  );
+
+  if (runIds.length === 0) {
+    return (
+      <section className="state">
+        <p className="state__title">No runs selected</p>
+        <p className="state__detail">
+          Pick runs in the run browser and choose Compare, or pass them directly as
+          <code> /compare?runs=a,b,c</code>.
+        </p>
+        <Link className="button" to="/runs">
+          Go to runs
+        </Link>
+      </section>
+    );
+  }
+
+  if (loading) return <LoadingState />;
+
+  if (runs.length === 0) {
+    return (
+      <ErrorState
+        message={
+          failures.length
+            ? `None of the selected runs could be loaded. ${failures[0]?.message ?? ""}`
+            : "None of the selected runs could be loaded."
+        }
+        onRetry={reload}
+      />
+    );
+  }
+
+  const excluded = runs.filter((run) => run.excluded !== null);
+  const mixedAxes = mixedAxisWarning(runs);
+
+  return (
+    <article className="detail">
+      <header className="runheader">
+        <div className="runheader__title">
+          <Link to="/runs" className="runheader__back">
+            ← Runs
+          </Link>
+          <h1>Comparing {runs.length} runs</h1>
+        </div>
+      </header>
+
+      {failures.length > 0 && (
+        <p className="panel__status panel__status--error" role="alert">
+          Could not load: {failures.map((failure) => `${failure.runId} (${failure.message})`).join("; ")}
+        </p>
+      )}
+
+      {excluded.length > 0 && (
+        // Excluded-and-why, not silently dropped: a run missing from the overlay
+        // with no explanation looks like a bug.
+        <div className="panel__status panel__status--notice" role="status">
+          <p>Not included in the overlays:</p>
+          <ul className="compare__excluded">
+            {excluded.map((run) => (
+              <li key={run.runId}>
+                <strong>{runLabel(run)}</strong> — {run.excluded}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {mixedAxes && (
+        <p className="panel__status panel__status--notice" role="status">
+          {mixedAxes}
+        </p>
+      )}
+
+      <CompareSummary runs={runs} onRemove={removeRun} />
+      <CompareProfiles runs={runs} />
+      <CompareLoss runs={runs} />
+      <CompareConfig runs={runs} />
+    </article>
+  );
+}

--- a/frontend/src/routes/Compare.tsx
+++ b/frontend/src/routes/Compare.tsx
@@ -16,11 +16,11 @@ import { CompareProfiles } from "../components/CompareProfiles";
 import { CompareSummary } from "../components/CompareSummary";
 import { ErrorState, LoadingState } from "../components/StateViews";
 import { useComparison } from "../hooks/useComparison";
-import { mixedAxisWarning, parseRunIds, runLabel } from "../lib/compare";
+import { MAX_COMPARE_RUNS, mixedAxisWarning, parseRunIds, runLabel } from "../lib/compare";
 
 export function Compare() {
   const [search, setSearch] = useSearchParams();
-  const runIds = useMemo(() => parseRunIds(search.get("runs")), [search]);
+  const { ids: runIds, requested } = useMemo(() => parseRunIds(search.get("runs")), [search]);
 
   const { runs, failures, loading, reload } = useComparison(runIds);
 
@@ -78,6 +78,16 @@ export function Compare() {
           <h1>Comparing {runs.length} runs</h1>
         </div>
       </header>
+
+      {requested > runIds.length && (
+        // Said out loud rather than truncated silently: someone who pasted 30 run
+        // ids needs to know which ones they are looking at.
+        <p className="panel__status panel__status--notice" role="status">
+          The URL asked for {requested} runs. Showing the first {runIds.length} — a comparison is
+          capped at {MAX_COMPARE_RUNS} runs, beyond which trace colours repeat and the overlay stops
+          distinguishing them.
+        </p>
+      )}
 
       {failures.length > 0 && (
         <p className="panel__status panel__status--error" role="alert">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -533,3 +533,76 @@ body {
 .filelist__size {
   color: var(--muted);
 }
+
+/* -- compare -- */
+
+.comparetable__scroll {
+  overflow-x: auto;
+}
+
+.comparetable {
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  min-width: 100%;
+}
+
+.comparetable th,
+.comparetable td {
+  text-align: left;
+  padding: 0.3rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.comparetable thead th {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.comparetable tbody th {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.comparetable__remove {
+  margin-left: 0.35rem;
+  border: 0;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.comparetable__remove:hover {
+  color: var(--danger);
+}
+
+.comparetable__losskey,
+.comparetable__stage {
+  color: var(--muted);
+}
+
+.comparetable__row--varies th[scope="row"] {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.comparetable__absent {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.compare__excluded {
+  margin: 0.35rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}


### PR DESCRIPTION
Closes #33. Now based on `main` — #42 has landed, and this branch was rebuilt as `main` plus the compare-only delta (the squash-merge hazard #41 hit; confirmed the squash preserved content before rebasing, so the diff is 12 files rather than re-adding #42's).

Entry via `/compare?runs=a,b,c`, which the run browser's multi-select has linked to since #41.

## Most of this diff is refusals

The hard part of comparing runs isn't plotting — it's knowing when a comparison would be meaningless:

- **Angular runs are excluded from the overlays, with a reason.** Their x axis is scattering angle, so sharing an axis with `Time (ps)` isn't a degraded comparison but a meaningless one. Excluded-*and-why*, never silently dropped: a run missing from a legend with no explanation reads as a bug.
- **The config diff deliberately stays inclusive.** Flattened key → per-run values doesn't care about axis semantics, so an angular run's config is still perfectly comparable and appears in that table even though its profiles can't be overlaid. That's the exception #37's scope note calls out, and there's a test for it.
- **Mixing spatial and temporal 1D runs is the same problem, milder.** `Radius (μm)` and `Time (ps)` aren't the same axis either. Those get plotted with a warning, since a deliberate comparison is imaginable — and the x-axis title names *both* labels rather than picking one and lying.
- **Runs legitimately differ in which parameters they fitted.** An ele-only run has no ion parameters, so the union of series is taken and each panel reports "1 of 2 runs fitted this parameter". Dropping a parameter because one run lacks it would hide data the others have.
- **Loss metrics differ between runs.** The summary names each run's `loss_key` and warns when the column mixes metrics; the curve panel offers the union of keys and names the runs that didn't log the selected one.
- **A key absent from one run is distinct from a differing value**, so the diff shows `absent` rather than a blank cell — that difference matters when runs came from different decks.
- **A failed profiles request is distinct from a run with no profiles.** Both leave the run out of the overlay, but only one is worth retrying, and reporting a 500 as "no fitted-parameter profiles logged" sends a physicist to look at their input deck.

## Arbitrary input, not a curated selection

Because the URL fully encodes the comparison (which is the point — it can be pasted into Slack), the run ids are hand-editable input rather than something the run browser vetted. So:

- parsing drops blanks, whitespace and duplicates
- **the comparison is capped at 10 runs**, and the page says *"The URL asked for 30 runs. Showing the first 10"* rather than truncating in silence. Ten because Plotly's default colorway has ten entries — an eleventh trace reuses the first colour and two runs stop being distinguishable. The cap lives inside `parseRunIds` so no call site can skip it, and it bounds the fan-out: every run costs up to three concurrent requests, so a hand-edited URL could otherwise turn one page load into hundreds of them. The test asserts the dropped runs are never *fetched*, since capping only the render would miss the point.
- one run failing to load doesn't fail the page — the rest are still compared and the failure is reported in an alert
- removing a run rewrites the URL, so the view stays shareable rather than diverging from its link

The diff reads `config_flat` — the raw params as MLflow stores them — rather than the reconstructed tree, so a failed unflattening on one run can't skew the comparison.

## Loading

Each run is fetched independently and a failure is recorded against that run rather than failing the page. An **abort is not a failure**: `api.profiles(...).catch(() => null)` would have treated a cancelled request identically to a run with no profiles, so a superseded load could resolve a run carrying the wrong exclusion reason. Aborts rethrow, which is the path the caller's aborted-result handling already expects.

The two heaviest panels are memoized and wrapped in `memo`, since `Plot` re-plots on identity and this route re-renders on every URL change. That only works because `onRemove` and `reload` are both stable.

## Testing

129 frontend tests (46 new: 22 unit on the comparison logic, 24 integration on the view). Backend unchanged at 162.

```
$ npm run typecheck && npm test && npm run build
Test Files  9 passed (9)
     Tests  129 passed (129)
index.js  396.74 kB │ gzip: 125.46 kB     (Plotly stays a separate chunk)
```

Plotly is mocked, so the assertions are about the traces each panel builds — including that an angular run contributes **zero** traces to an overlay while still contributing a **column** to the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM8XjWjnJ1iKv19BS9c9Ab)_